### PR TITLE
[NEW] Cyclic boosting interface

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -99,6 +99,27 @@
         "doc",
         "ideas"
       ]
+    },
+    {
+      "login": "FelixWick",
+      "name": "Felix Wick",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7291058?v=4",
+      "profile": "https://github.com/FelixWick",
+      "contributions": [
+        "ideas",
+        "review"
+      ]
+    },
+    {
+      "login": "setoguchi-naoki",
+      "name": "Naoki Setoguchi",
+      "avatar_url": "https://avatars.githubusercontent.com/u/104494531?v=4",
+      "profile": "https://github.com/setoguchi-naoki",
+      "contributions": [
+        "code",
+        "doc",
+        "test"
+      ]
     }
   ]
 }

--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -35,6 +35,7 @@ Parametric distributions
     Laplace
     Normal
     TDistribution
+    QPD_U
     QPD_S
     QPD_B
 

--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -35,9 +35,6 @@ Parametric distributions
     Laplace
     Normal
     TDistribution
-    QPD_U
-    QPD_S
-    QPD_B
 
 Non-parametric and empirical distributions
 ------------------------------------------
@@ -49,6 +46,9 @@ Non-parametric and empirical distributions
     :template: class.rst
 
     Empirical
+    QPD_U
+    QPD_S
+    QPD_B
 
 Composite distributions
 -----------------------

--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -35,6 +35,7 @@ Parametric distributions
     Laplace
     Normal
     TDistribution
+    J_QPD_S
 
 Non-parametric and empirical distributions
 ------------------------------------------

--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -35,7 +35,8 @@ Parametric distributions
     Laplace
     Normal
     TDistribution
-    J_QPD_S
+    QPD_S
+    QPD_B
 
 Non-parametric and empirical distributions
 ------------------------------------------

--- a/docs/source/api_reference/regression.rst
+++ b/docs/source/api_reference/regression.rst
@@ -79,6 +79,14 @@ take one or multiple ``sklearn`` estimators and adda probabilistic prediction mo
 
     MapieRegressor
 
+.. currentmodule:: skpro.regression.cyclic_boosting
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    CyclicBoosting
+
 Base
 ----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ all_extras = [
     "statsmodels>=0.12.1",
     "tabulate",
     "uncertainties",
-    "cyclic-boosting>=1.2.5"
+    "cyclic-boosting>=1.2.5; python_version < '3.12'"
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
     "scikit-base>=0.4.3,<0.7.0",
     "scikit-learn>=0.24.0,<1.4.0",
     "scipy<2.0.0,>=1.2.0",
-    "cyclic-boosting>=1.2.1"
 ]
 
 [project.optional-dependencies]
@@ -60,6 +59,7 @@ all_extras = [
     "statsmodels>=0.12.1",
     "tabulate",
     "uncertainties",
+    "cyclic-boosting>=1.2.1"
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "scikit-base>=0.4.3,<0.7.0",
     "scikit-learn>=0.24.0,<1.4.0",
     "scipy<2.0.0,>=1.2.0",
+    "cyclic-boosting>=1.2.1"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ all_extras = [
     "statsmodels>=0.12.1",
     "tabulate",
     "uncertainties",
-    "cyclic-boosting>=1.2.1"
+    "cyclic-boosting>=1.2.5"
 ]
 
 dev = [

--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -17,7 +17,5 @@ from skpro.distributions.empirical import Empirical
 from skpro.distributions.laplace import Laplace
 from skpro.distributions.mixture import Mixture
 from skpro.distributions.normal import Normal
+from skpro.distributions.qpd import QPD_B, QPD_S, QPD_U
 from skpro.distributions.t import TDistribution
-from skpro.distributions.qpd import QPD_S
-from skpro.distributions.qpd import QPD_B
-from skpro.distributions.qpd import QPD_U

--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "TDistribution",
     "QPD_S",
     "QPD_B",
+    "QPD_U",
 ]
 
 from skpro.distributions.empirical import Empirical
@@ -19,3 +20,4 @@ from skpro.distributions.normal import Normal
 from skpro.distributions.t import TDistribution
 from skpro.distributions.qpd import QPD_S
 from skpro.distributions.qpd import QPD_B
+from skpro.distributions.qpd import QPD_U

--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -2,11 +2,20 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 # adapted from sktime
 
-__all__ = ["Empirical", "Laplace", "Mixture", "Normal", "TDistribution", "J_QPD_S"]
+__all__ = [
+    "Empirical",
+    "Laplace",
+    "Mixture",
+    "Normal",
+    "TDistribution",
+    "QPD_S",
+    "QPD_B",
+]
 
 from skpro.distributions.empirical import Empirical
 from skpro.distributions.laplace import Laplace
 from skpro.distributions.mixture import Mixture
 from skpro.distributions.normal import Normal
 from skpro.distributions.t import TDistribution
-from skpro.distributions.qpd import J_QPD_S
+from skpro.distributions.qpd import QPD_S
+from skpro.distributions.qpd import QPD_B

--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -2,16 +2,11 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 # adapted from sktime
 
-__all__ = [
-    "Empirical",
-    "Laplace",
-    "Mixture",
-    "Normal",
-    "TDistribution",
-]
+__all__ = ["Empirical", "Laplace", "Mixture", "Normal", "TDistribution", "J_QPD_S"]
 
 from skpro.distributions.empirical import Empirical
 from skpro.distributions.laplace import Laplace
 from skpro.distributions.mixture import Mixture
 from skpro.distributions.normal import Normal
 from skpro.distributions.t import TDistribution
+from skpro.distributions.qpd import J_QPD_S

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -64,7 +64,7 @@ class QPD_S(BaseDistribution):
     """
 
     _tags = {
-        "capabilities:approx": ["pdfnorm"],
+        "capabilities:approx": [],
         "capabilities:exact": ["mean", "var", "cdf", "ppf"],
         "distr:measuretype": "continuous",
     }
@@ -271,10 +271,23 @@ class QPD_B(BaseDistribution):
     dist_shape: str
         parameter modifying the logistic base distribution via
         sinh/arcsinh-scaling (only active in sinhlogistic version)
+
+    Example
+    -------
+    >>> from skpro.distributions.qpd import QPD_B
+
+    >>> qpd = QPD_S(
+    ...         lower=0.2,
+    ...         qv_low=[[1, 2], [3, 4]],
+    ...         qv_median=[[3, 4], [5, 6]],
+    ...         qv_high=[[5, 6], [7, 8]],
+    ...         lower=0,
+    ...         upper=10
+    ...       )
     """
 
     _tags = {
-        "capabilities:approx": ["pdfnorm"],
+        "capabilities:approx": [],
         "capabilities:exact": ["mean", "var", "cdf", "ppf"],
         "distr:measuretype": "continuous",
     }
@@ -488,10 +501,21 @@ class QPD_U(BaseDistribution):
     dist_shape: str
         parameter modifying the logistic base distribution via
         sinh/arcsinh-scaling (only active in sinhlogistic version)
+
+    Example
+    -------
+    >>> from skpro.distributions.qpd import QPD_U
+
+    >>> qpd = QPD_S(
+    ...         lower=0.2,
+    ...         qv_low=[[1, 2], [3, 4]],
+    ...         qv_median=[[3, 4], [5, 6]],
+    ...         qv_high=[[5, 6], [7, 8]],
+    ...       )
     """
 
     _tags = {
-        "capabilities:approx": ["pdfnorm"],
+        "capabilities:approx": [],
         "capabilities:exact": ["mean", "var", "cdf", "ppf"],
         "distr:measuretype": "continuous",
     }

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -11,7 +11,6 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
-
 from scipy.integrate import quad
 from scipy.misc import derivative
 from scipy.stats import logistic, norm
@@ -316,7 +315,7 @@ class QPD_B(BaseDistribution):
         self.columns = columns
 
         super().__init__(index=index, columns=columns)
-        
+
         from cyclic_boosting.quantile_matching import J_QPD_extended_B
 
         for qv in [alpha, qv_low, qv_median, qv_high]:

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -17,7 +17,6 @@ from scipy.integrate import quad
 from typing import Optional
 
 from skpro.distributions.base import BaseDistribution
-from cyclic_boosting.quantile_matching import J_QPD_S, J_QPD_B
 
 
 class QPD_S(BaseDistribution):
@@ -69,6 +68,10 @@ class QPD_S(BaseDistribution):
         self.l = l
         self.index = index
         self.columns = columns
+
+        super().__init__(index=index, columns=columns)
+
+        from cyclic_boosting.quantile_matching import J_QPD_S
 
         for qv in [alpha, qv_low, qv_median, qv_high]:
             if isinstance(qv, float):
@@ -123,8 +126,6 @@ class QPD_S(BaseDistribution):
             )
             self.qpd.append(jqpd)
         self.qpd = pd.DataFrame(self.qpd, index=index)
-
-        super().__init__(index=index, columns=columns)
 
     def mean(self, lower=0.0, upper=np.inf):
         loc = []
@@ -253,6 +254,10 @@ class QPD_B(BaseDistribution):
         self.index = index
         self.columns = columns
 
+        super().__init__(index=index, columns=columns)
+        
+        from cyclic_boosting.quantile_matching import J_QPD_B
+
         for qv in [alpha, qv_low, qv_median, qv_high]:
             if isinstance(qv, float):
                 qv = np.array([qv])
@@ -307,8 +312,6 @@ class QPD_B(BaseDistribution):
             )
             self.qpd.append(jqpd)
         self.qpd = pd.DataFrame(self.qpd, index=index)
-
-        super().__init__(index=index, columns=columns)
 
     def mean(self, lower=0.0, upper=np.inf):
         loc = []

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -455,8 +455,8 @@ class QPD_B(BaseDistribution):
             "qv_low": 0.2,
             "qv_median": 0.5,
             "qv_high": 0.8,
-            "l": 0.0,
-            "u": 1.0,
+            "lower": 0.0,
+            "upper": 1.0,
         }
         params2 = {
             "alpha": 0.2,
@@ -464,8 +464,8 @@ class QPD_B(BaseDistribution):
             "qv_low": [0.2, 0.2, 0.2],
             "qv_median": [0.5, 0.5, 0.5],
             "qv_high": [0.8, 0.8, 0.8],
-            "l": 0.0,
-            "u": 1.0,
+            "lower": 0.0,
+            "upper": 1.0,
             "index": pd.Index([1, 2, 5]),
             "columns": pd.Index(["a"]),
         }

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -11,7 +11,11 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
-from cyclic_boosting.quantile_matching import J_QPD_B, J_QPD_S
+from cyclic_boosting.quantile_matching import (
+    J_QPD_extended_S,
+    J_QPD_extended_B,
+    J_QPD_extended_U,
+)
 from scipy.integrate import quad
 from scipy.misc import derivative
 from scipy.stats import logistic, norm
@@ -38,10 +42,13 @@ class QPD_S(BaseDistribution):
         quantile function value of quantile 0.5
     qv_high : float or array_like[float]
         quantile function value of quantile ``1 - alpha``
-    l : float
+    lower : float
         lower bound of semi-bounded range (default is 0)
     version: str
         options are ``normal`` (default) or ``logistic``
+    dist_shape: str
+        parameter modifying the logistic base distribution via
+        sinh/arcsinh-scaling (only active in sinhlogistic version)
 
     Example
     -------
@@ -52,7 +59,7 @@ class QPD_S(BaseDistribution):
     ...         qv_low=[[1, 2], [3, 4]],
     ...         qv_median=[[3, 4], [5, 6]],
     ...         qv_high=[[5, 6], [7, 8]],
-    ...         l=0
+    ...         lower=0
     ...       )
     """
 
@@ -68,18 +75,20 @@ class QPD_S(BaseDistribution):
         qv_low: float or object,
         qv_median: float or object,
         qv_high: float or object,
-        l: Optional[float] = 0,
+        lower: Optional[float] = 0,
         version: Optional[str] = "normal",
+        dist_shape: Optional[float] = 0,
         index=None,
         columns=None,
     ):
         self.qpd = []
         self.alpha = alpha
-        self.version = version
         self.qv_low = qv_low
         self.qv_median = qv_median
         self.qv_high = qv_high
-        self.l_ = l
+        self.lower = lower
+        self.version = version
+        self.dist_shape = dist_shape
         self.index = index
         self.columns = columns
 
@@ -129,13 +138,14 @@ class QPD_S(BaseDistribution):
 
         iter = np.nditer(qv_low, flags=["c_index"])
         for _i in iter:
-            jqpd = J_QPD_S(
+            jqpd = J_QPD_extended_S(
                 alpha=alpha,
                 qv_low=qv_low[iter.index],
                 qv_median=qv_median[iter.index],
                 qv_high=qv_high[iter.index],
-                l=self.l_,
+                l=self.lower,
                 version=version,
+                shape=dist_shape,
             )
             self.qpd.append(jqpd)
         self.qpd = pd.DataFrame(self.qpd, index=index)
@@ -252,12 +262,15 @@ class QPD_B(BaseDistribution):
         quantile function value of quantile 0.5
     qv_high : float or array_like[float]
         quantile function value of quantile ``1 - alpha``
-    l : float
+    lower : float
         lower bound of semi-bounded range
-    u : float
+    upper : float
         upper bound of supported range
     version: str
         options are ``normal`` (default) or ``logistic``
+    dist_shape: str
+        parameter modifying the logistic base distribution via
+        sinh/arcsinh-scaling (only active in sinhlogistic version)
     """
 
     _tags = {
@@ -272,20 +285,22 @@ class QPD_B(BaseDistribution):
         qv_low: float or object,
         qv_median: float or object,
         qv_high: float or object,
-        l: float,
-        u: float,
+        lower: float,
+        upper: float,
         version: Optional[str] = "normal",
+        dist_shape: Optional[float] = 0,
         index=None,
         columns=None,
     ):
         self.qpd = []
         self.alpha = alpha
-        self.version = version
         self.qv_low = qv_low
         self.qv_median = qv_median
         self.qv_high = qv_high
-        self.l_ = l
-        self.u = u
+        self.lower = lower
+        self.upper = upper
+        self.version = version
+        self.dist_shape = dist_shape
         self.index = index
         self.columns = columns
 
@@ -335,14 +350,15 @@ class QPD_B(BaseDistribution):
 
         iter = np.nditer(qv_low, flags=["c_index"])
         for _i in iter:
-            jqpd = J_QPD_B(
+            jqpd = J_QPD_extended_B(
                 alpha=alpha,
                 qv_low=qv_low[iter.index],
                 qv_median=qv_median[iter.index],
                 qv_high=qv_high[iter.index],
-                l=self.l_,
-                u=self.u,
+                l=lower,
+                u=upper,
                 version=version,
+                shape=dist_shape,
             )
             self.qpd.append(jqpd)
         self.qpd = pd.DataFrame(self.qpd, index=index)
@@ -438,6 +454,213 @@ class QPD_B(BaseDistribution):
             "qv_high": [0.8, 0.8, 0.8],
             "l": 0.0,
             "u": 1.0,
+            "index": pd.Index([1, 2, 5]),
+            "columns": pd.Index(["a"]),
+        }
+        return [params1, params2]
+
+
+class QPD_U(BaseDistribution):
+    """Johnson Quantile-Parameterized Distributions with unbounded mode.
+
+    see https://repositories.lib.utexas.edu/bitstream/handle/2152
+        /63037/HADLOCK-DISSERTATION-2017.pdf
+    (Due to the Python keyword, the parameter lambda from
+    this reference is named kappa below).
+    A distribution is parameterized by a symmetric-percentile triplet (SPT).
+
+    Parameters
+    ----------
+    alpha : float
+        lower quantile of SPT (upper is ``1 - alpha``)
+    qv_low : float or array_like[float]
+        quantile function value of ``alpha``
+    qv_median : float or array_like[float]
+        quantile function value of quantile 0.5
+    qv_high : float or array_like[float]
+        quantile function value of quantile ``1 - alpha``
+    l : float
+        lower bound of semi-bounded range
+    u : float
+        upper bound of supported range
+    version: str
+        options are ``normal`` (default) or ``logistic``
+    dist_shape: str
+        parameter modifying the logistic base distribution via
+        sinh/arcsinh-scaling (only active in sinhlogistic version)
+    """
+
+    _tags = {
+        "capabilities:approx": ["pdfnorm"],
+        "capabilities:exact": ["mean", "var", "cdf", "ppf"],
+        "distr:measuretype": "continuous",
+    }
+
+    def __init__(
+        self,
+        alpha: float,
+        qv_low: float or object,
+        qv_median: float or object,
+        qv_high: float or object,
+        version: Optional[str] = "normal",
+        dist_shape: Optional[float] = 0,
+        index=None,
+        columns=None,
+    ):
+        self.qpd = []
+        self.alpha = alpha
+        self.qv_low = qv_low
+        self.qv_median = qv_median
+        self.qv_high = qv_high
+        self.version = version
+        self.dist_shape = dist_shape
+        self.index = index
+        self.columns = columns
+
+        for qv in [alpha, qv_low, qv_median, qv_high]:
+            if isinstance(qv, float):
+                qv = np.array([qv])
+            elif (
+                isinstance(qv, tuple)
+                or isinstance(qv, list)
+                or isinstance(qv, np.ndarray)
+            ):
+                qv = np.array(qv)
+            else:
+                raise ValueError("data type is not float or array_like object")
+
+        shape = self.qv_low.shape
+        if index is None:
+            self.index = index
+            index = pd.RangeIndex(shape[0])
+
+        if columns is None:
+            self.columns = columns
+            columns = pd.RangeIndex(shape[1])
+
+        if version == "normal":
+            self.phi = norm()
+        elif version == "logistic":
+            self.phi = logistic()
+        else:
+            raise Exception("Invalid version.")
+
+        if (np.any(qv_low > qv_median)) or np.any(qv_high < qv_median):
+            warnings.warn(
+                "The SPT values are not monotonically increasing, "
+                "each SPT will be replaced by mean value",
+                stacklevel=2,
+            )
+            idx = np.where((qv_low > qv_median), True, False) + np.where(
+                (qv_high < qv_median), True, False
+            )
+            warnings.warn(
+                f"replaced index by mean {np.argwhere(idx > 0).tolist()}", stacklevel=2
+            )
+            qv_low[idx] = np.nanmean(qv_low)
+            qv_median[idx] = np.nanmean(qv_median)
+            qv_high[idx] = np.nanmean(qv_high)
+
+        iter = np.nditer(qv_low, flags=["c_index"])
+        for _i in iter:
+            jqpd = J_QPD_extended_U(
+                alpha=alpha,
+                qv_low=qv_low[iter.index],
+                qv_median=qv_median[iter.index],
+                qv_high=qv_high[iter.index],
+                version=version,
+                shape=dist_shape,
+            )
+            self.qpd.append(jqpd)
+        self.qpd = pd.DataFrame(self.qpd, index=index)
+
+        super().__init__(index=index, columns=columns)
+
+    def mean(self, lower=0.0, upper=np.inf):
+        """Return expected value of the distribution.
+
+        Returns
+        -------
+        pd.DataFrame with same rows, columns as `self`
+        expected value of distribution (entry-wise)
+        """
+        loc = []
+        for idx in self.index:
+            qpd = self.qpd.loc[idx, :].values[0]
+            l, _ = quad(exp_func, args=(qpd), a=lower, b=upper)
+            loc.append(l)
+        loc_arr = np.array(loc)
+        return pd.DataFrame(loc_arr, index=self.index, columns=self.columns)
+
+    def var(self, lower=0.0, upper=np.inf):
+        """Return element/entry-wise variance of the distribution.
+
+        Returns
+        -------
+        pd.DataFrame with same rows, columns as `self`
+        variance of distribution (entry-wise)
+        """
+        mean = self.mean()
+        var = []
+        for idx in self.index:
+            mu = mean.loc[idx, :].to_numpy()
+            qpd = self.qpd.loc[idx, :].values[0]
+            l, _ = quad(var_func, args=(mu, qpd), a=lower, b=upper)
+            var.append(l)
+        var_arr = np.array(var)
+        return pd.DataFrame(var_arr, index=self.index, columns=self.columns)
+
+    def pdf(self, x: pd.DataFrame):
+        """Probability density function.
+
+        this fucntion transform cdf to pdf
+        because j-qpd's pdf calculation is bit complex
+        """
+        pdf = []
+        for idx in x.index:
+            qpd = self.qpd.loc[idx, :].values[0]
+            _x = x.loc[idx, :]
+            _pdf = [derivative(qpd.cdf, x0, dx=1e-6) for x0 in _x]
+            pdf.append(_pdf)
+        pdf_arr = np.array(pdf)
+        return pd.DataFrame(pdf_arr, index=x.index, columns=x.columns)
+
+    def ppf(self, p: pd.DataFrame):
+        """Quantile function = percent point function = inverse cdf."""
+        ppf = []
+        for idx in p.index:
+            qpd = self.qpd.loc[idx, :].values[0]
+            _ppf = qpd.ppf(p.loc[idx, :])
+            ppf.append(_ppf)
+        ppf_arr = np.array(ppf)
+        return pd.DataFrame(ppf_arr, index=p.index, columns=p.columns)
+
+    def cdf(self, x: pd.DataFrame):
+        """Cumulative distribution function."""
+        cdf = []
+        for idx in x.index:
+            qpd = self.qpd.loc[idx, :].values[0]
+            _cdf = qpd.cdf(x.loc[idx, :])
+            cdf.append(_cdf)
+        cdf_arr = np.array(cdf)
+        return pd.DataFrame(cdf_arr, index=x.index, columns=x.columns)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        params1 = {
+            "alpha": 0.2,
+            "version": "normal",
+            "qv_low": 0.2,
+            "qv_median": 0.5,
+            "qv_high": 0.8,
+        }
+        params2 = {
+            "alpha": 0.2,
+            "version": "normal",
+            "qv_low": [0.2, 0.2, 0.2],
+            "qv_median": [0.5, 0.5, 0.5],
+            "qv_high": [0.8, 0.8, 0.8],
             "index": pd.Index([1, 2, 5]),
             "columns": pd.Index(["a"]),
         }

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -11,11 +11,7 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
-from cyclic_boosting.quantile_matching import (
-    J_QPD_extended_S,
-    J_QPD_extended_B,
-    J_QPD_extended_U,
-)
+
 from scipy.integrate import quad
 from scipy.misc import derivative
 from scipy.stats import logistic, norm

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -1,0 +1,245 @@
+"""J-QPD probability distribution."""
+
+__author__ = ["FelixWick", "setoguchi-naoki"]
+
+import pandas as pd
+import numpy as np
+import warnings
+
+from numpy import exp, log, sinh, arcsinh, arccosh
+from scipy.stats import norm, logistic
+from scipy.misc import derivative
+from scipy.integrate import quad
+
+from typing import Optional
+
+from skpro.distributions.base import BaseDistribution
+
+
+class J_QPD_S(BaseDistribution):
+    """Johnson Quantile-Parameterized Distributions
+
+    see https://repositories.lib.utexas.edu/bitstream/handle/2152/63037/HADLOCK-DISSERTATION-2017.pdf
+    (Due to the Python keyword, the parameter lambda from this reference is named kappa below.).
+    A distribution is parameterized by a symmetric-percentile triplet (SPT).
+
+    Parameters
+    ----------
+    alpha : float
+        lower quantile of SPT (upper is ``1 - alpha``)
+    qv_low : float or array_like[float]
+        quantile function value of ``alpha``
+    qv_median : float or array_like[float]
+        quantile function value of quantile 0.5
+    qv_high : float or array_like[float]
+        quantile function value of quantile ``1 - alpha``
+    l : float
+        lower bound of semi-bounded range (default is 0)
+    version: str
+        options are ``normal`` (default) or ``logistic``
+    """
+
+    _tags = {
+        "capabilities:approx": ["pdfnorm"],
+        "capabilities:exact": ["mean", "var", "cdf", "ppf"],
+        "distr:measuretype": "continuous",
+    }
+
+    def __init__(
+        self,
+        alpha: float,
+        qv_low: float or object,
+        qv_median: float or object,
+        qv_high: float or object,
+        l: Optional[float] = 0,
+        version: Optional[str] = "normal",
+        index=None,
+        columns=None,
+    ):
+        self.alpha = alpha
+        self.version = version
+        self.qv_low = qv_low
+        self.qv_median = qv_median
+        self.qv_high = qv_high
+        self.index = index
+        self.columns = columns
+
+        for qv in [qv_low, qv_median, qv_high]:
+            if isinstance(qv, float):
+                qv = np.array([qv])
+            elif (
+                isinstance(qv, tuple)
+                or isinstance(qv, list)
+                or isinstance(qv, np.ndarray)
+            ):
+                qv = np.array(qv)
+            else:
+                raise ValueError("data type is not float or array_like object")
+
+        if version == "normal":
+            self.phi = norm()
+        elif version == "logistic":
+            self.phi = logistic()
+        else:
+            raise Exception("Invalid version.")
+
+        if (np.any(qv_low > qv_median)) or np.any((qv_high < qv_median)):
+            warnings.warn(
+                "The SPT values are not monotonically increasing, each SPT will be replaced by mean value"
+            )
+            idx = np.where((qv_low > qv_median), True, False) + np.where(
+                (qv_high < qv_median), True, False
+            )
+            print(f"replaced index by mean {np.argwhere(idx > 0).tolist()}")
+            qv_low[idx] = np.nanmean(qv_low)
+            qv_median[idx] = np.nanmean(qv_median)
+            qv_high[idx] = np.nanmean(qv_high)
+
+        self.l = l
+        self.c = self.phi.ppf(1 - alpha)
+
+        self.L = log(qv_low - l)
+        self.H = log(qv_high - l)
+        self.B = log(qv_median - l)
+
+        self.n = np.zeros_like(self.L)
+        self.theta = qv_median - l
+
+        pos = np.where((self.L + self.H - 2 * self.B) > 0, True, False)
+        self.n[pos] = 1
+        self.theta[pos] = qv_low[pos] - l
+
+        neg = np.where((self.L + self.H - 2 * self.B) < 0, True, False)
+        self.n[neg] = -1
+        self.theta[neg] = qv_high[neg] - l
+
+        B_L = self.B - self.L
+        H_B = self.H - self.B
+        _min = np.where(B_L < H_B, B_L, H_B)
+
+        self.delta = 1.0 / self.c * sinh(arccosh((self.H - self.L) / (2 * _min)))
+        self.kappa = 1.0 / (self.delta * self.c) * _min
+
+        # DataFrame
+        self.L = pd.DataFrame(self.L, index=index)
+        self.H = pd.DataFrame(self.H, index=index)
+        self.B = pd.DataFrame(self.B, index=index)
+        self.n = pd.DataFrame(self.n, index=index)
+        self.theta = pd.DataFrame(self.theta, index=index)
+        self.delta = pd.DataFrame(self.delta, index=index)
+        self.kappa = pd.DataFrame(self.kappa, index=index)
+
+        super().__init__(index=index, columns=columns)
+
+    def mean(self):
+        def cdf_func(x, theta, kappa, delta, n):
+            cdf_arr = self.phi.cdf(
+                1.0
+                / delta
+                * sinh(
+                    arcsinh(1.0 / kappa * log((x - self.l) / theta))
+                    - arcsinh(n * self.c * delta)
+                )
+            )
+            return cdf_arr
+
+        def exp_func(x, theta, kappa, delta, n):
+            # TODO: scipy.integrate will be removed in scipy 1.12.0
+            pdf = derivative(cdf_func, x, dx=1e-6, args=(theta, kappa, delta, n))
+            return x * pdf
+
+        loc = []
+        for i in self.index:
+            theta = self.theta.loc[i, :].to_numpy()
+            kappa = self.kappa.loc[i, :].to_numpy()
+            delta = self.delta.loc[i, :].to_numpy()
+            n = self.n.loc[i, :].to_numpy()
+            # NOTE: integral interval should be checked, -inf to inf will be NaN
+            l, _ = quad(exp_func, args=(theta, kappa, delta, n), a=0.0, b=np.inf)
+            loc.append(l)
+
+        loc_arr = np.array(loc)
+        return pd.DataFrame(loc_arr, index=self.index, columns=self.columns)
+
+    def var(self):
+        def cdf_func(x, theta, kappa, delta, n):
+            cdf_arr = self.phi.cdf(
+                1.0
+                / delta
+                * sinh(
+                    arcsinh(1.0 / kappa * log((x - self.l) / theta))
+                    - arcsinh(n * self.c * delta)
+                )
+            )
+            return cdf_arr
+
+        def var_func(x, mu, theta, kappa, delta, n):
+            # TODO: scipy.integrate will be removed in scipy 1.12.0
+            pdf = derivative(cdf_func, x, dx=1e-6, args=(theta, kappa, delta, n))
+            return ((x - mu) ** 2) * pdf
+
+        mean = self.mean()
+        var = []
+        for i in self.index:
+            theta = self.theta.loc[i, :].to_numpy()
+            kappa = self.kappa.loc[i, :].to_numpy()
+            delta = self.delta.loc[i, :].to_numpy()
+            n = self.n.loc[i, :].to_numpy()
+            mu = mean.loc[i, :].to_numpy()
+            # NOTE: integral interval should be checked, -inf to inf will be NaN
+            l, _ = quad(var_func, args=(mu, theta, kappa, delta, n), a=0.0, b=np.inf)
+            var.append(l)
+
+        var_arr = np.array(var)
+        return pd.DataFrame(var_arr, index=self.index, columns=self.columns)
+
+    def pdf(self, x):
+        # cdf -> pdf calculation because j-qpd's pdf calculation is bit complex
+        def cdf_func(x, theta, kappa, delta, n):
+            cdf_arr = self.phi.cdf(
+                1.0
+                / delta
+                * sinh(
+                    arcsinh(1.0 / kappa * log((x - self.l) / theta))
+                    - arcsinh(n * self.c * delta)
+                )
+            )
+            return cdf_arr
+
+        pdf = []
+        for i in x.index:
+            theta = self.theta.loc[i, :].to_numpy()
+            kappa = self.kappa.loc[i, :].to_numpy()
+            delta = self.delta.loc[i, :].to_numpy()
+            n = self.n.loc[i, :].to_numpy()
+
+            p = derivative(cdf_func, x, dx=1e-6, args=(theta, kappa, delta, n))
+            pdf.append(p)
+
+        pdf_arr = np.array(pdf)
+        return pd.DataFrame(pdf_arr, index=x.index, columns=["pdf"])
+
+    def ppf(self, p):
+        theta = self.theta.loc[p.index, :].to_numpy()
+        kappa = self.kappa.loc[p.index, :].to_numpy()
+        delta = self.delta.loc[p.index, :].to_numpy()
+        n = self.n.loc[p.index, :].to_numpy()
+        ppf_arr = self.l + theta * exp(
+            kappa * sinh(arcsinh(delta * self.phi.ppf(p)) + arcsinh(n * self.c * delta))
+        )
+        return pd.DataFrame(ppf_arr, index=p.index, columns=p.columns)
+
+    def cdf(self, x):
+        theta = self.theta.loc[x.index, :].to_numpy()
+        kappa = self.kappa.loc[x.index, :].to_numpy()
+        delta = self.delta.loc[x.index, :].to_numpy()
+        n = self.n.loc[x.index, :].to_numpy()
+        cdf_arr = self.phi.cdf(
+            1.0
+            / delta
+            * sinh(
+                arcsinh(1.0 / kappa * log((x - self.l) / theta))
+                - arcsinh(n * self.c * delta)
+            )
+        )
+        return pd.DataFrame(cdf_arr, index=x.index, columns=x.columns)

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -47,15 +47,17 @@ class QPD_S(BaseDistribution):
 
     Example
     -------
-    >>> from skpro.distributions.qpd import QPD_S
+    >>> from skpro.distributions.qpd import QPD_S  # doctest: +SKIP
 
     >>> qpd = QPD_S(
-    ...         lower=0.2,
-    ...         qv_low=[[1, 2], [3, 4]],
-    ...         qv_median=[[3, 4], [5, 6]],
-    ...         qv_high=[[5, 6], [7, 8]],
+    ...         alpha=0.2,
+    ...         qv_low=[1, 2],
+    ...         qv_median=[3, 4],
+    ...         qv_high=[5, 6],
     ...         lower=0
-    ...       )
+    ...       )  # doctest: +SKIP
+
+    >>> qpd.mean()  # doctest: +SKIP
     """
 
     _tags = {
@@ -71,9 +73,9 @@ class QPD_S(BaseDistribution):
         qv_low: float or object,
         qv_median: float or object,
         qv_high: float or object,
-        lower: Optional[float] = 0,
+        lower: Optional[float] = 0.0,
         version: Optional[str] = "normal",
-        dist_shape: Optional[float] = 0,
+        dist_shape: Optional[float] = 0.0,
         index=None,
         columns=None,
     ):
@@ -92,26 +94,25 @@ class QPD_S(BaseDistribution):
 
         from cyclic_boosting.quantile_matching import J_QPD_extended_S
 
-        for qv in [alpha, qv_low, qv_median, qv_high]:
-            if isinstance(qv, float):
-                qv = np.array([qv])
+        params = [alpha, qv_low, qv_median, qv_high]
+        for idx, p in enumerate(params):
+            if isinstance(p, float):
+                params[idx] = np.array([p])
             elif (
-                isinstance(qv, tuple)
-                or isinstance(qv, list)
-                or isinstance(qv, np.ndarray)
+                isinstance(p, tuple) or isinstance(p, list) or isinstance(p, np.ndarray)
             ):
-                qv = np.array(qv)
+                params[idx] = np.array(p)
             else:
                 raise ValueError("data type is not float or array_like object")
 
-        shape = self.qv_low.shape
+        alpha, qv_low, qv_median, qv_high = params[:]
         if index is None:
+            index = pd.RangeIndex(qv_low.shape[0])
             self.index = index
-            index = pd.RangeIndex(shape[0])
 
         if columns is None:
+            columns = pd.RangeIndex(1)
             self.columns = columns
-            columns = pd.RangeIndex(shape[1])
 
         if version == "normal":
             self.phi = norm()
@@ -148,7 +149,7 @@ class QPD_S(BaseDistribution):
                 shape=dist_shape,
             )
             self.qpd.append(jqpd)
-        self.qpd = pd.DataFrame(self.qpd, index=index)
+        self.qpd = pd.DataFrame(self.qpd, index=self.index)
 
     def mean(self, lower=0.0, upper=np.inf):
         """Return expected value of the distribution.
@@ -230,7 +231,7 @@ class QPD_S(BaseDistribution):
             "qv_high": 0.8,
         }
         params2 = {
-            "alpha": [0.2, 0.2, 0.2],
+            "alpha": 0.2,
             "version": "normal",
             "qv_low": [0.2, 0.2, 0.2],
             "qv_median": [0.5, 0.5, 0.5],
@@ -272,16 +273,18 @@ class QPD_B(BaseDistribution):
 
     Example
     -------
-    >>> from skpro.distributions.qpd import QPD_B
+    >>> from skpro.distributions.qpd import QPD_B  # doctest: +SKIP
 
-    >>> qpd = QPD_S(
-    ...         lower=0.2,
-    ...         qv_low=[[1, 2], [3, 4]],
-    ...         qv_median=[[3, 4], [5, 6]],
-    ...         qv_high=[[5, 6], [7, 8]],
+    >>> qpd = QPD_B(
+    ...         alpha=0.2,
+    ...         qv_low=[1, 2],
+    ...         qv_median=[3, 4],
+    ...         qv_high=[5, 6],
     ...         lower=0,
     ...         upper=10
-    ...       )
+    ...       )  # doctest: +SKIP
+
+    >>> qpd.mean()  # doctest: +SKIP
     """
 
     _tags = {
@@ -300,7 +303,7 @@ class QPD_B(BaseDistribution):
         lower: float,
         upper: float,
         version: Optional[str] = "normal",
-        dist_shape: Optional[float] = 0,
+        dist_shape: Optional[float] = 0.0,
         index=None,
         columns=None,
     ):
@@ -320,26 +323,25 @@ class QPD_B(BaseDistribution):
 
         from cyclic_boosting.quantile_matching import J_QPD_extended_B
 
-        for qv in [alpha, qv_low, qv_median, qv_high]:
-            if isinstance(qv, float):
-                qv = np.array([qv])
+        params = [alpha, qv_low, qv_median, qv_high]
+        for idx, p in enumerate(params):
+            if isinstance(p, float):
+                params[idx] = np.array([p])
             elif (
-                isinstance(qv, tuple)
-                or isinstance(qv, list)
-                or isinstance(qv, np.ndarray)
+                isinstance(p, tuple) or isinstance(p, list) or isinstance(p, np.ndarray)
             ):
-                qv = np.array(qv)
+                params[idx] = np.array(p)
             else:
                 raise ValueError("data type is not float or array_like object")
 
-        shape = self.qv_low.shape
+        alpha, qv_low, qv_median, qv_high = params[:]
         if index is None:
+            index = pd.RangeIndex(qv_low.shape[0])
             self.index = index
-            index = pd.RangeIndex(shape[0])
 
         if columns is None:
+            columns = pd.RangeIndex(1)
             self.columns = columns
-            columns = pd.RangeIndex(shape[1])
 
         if version == "normal":
             self.phi = norm()
@@ -377,7 +379,7 @@ class QPD_B(BaseDistribution):
                 shape=dist_shape,
             )
             self.qpd.append(jqpd)
-        self.qpd = pd.DataFrame(self.qpd, index=index)
+        self.qpd = pd.DataFrame(self.qpd, index=self.index)
 
     def mean(self, lower=0.0, upper=np.inf):
         """Return expected value of the distribution.
@@ -493,10 +495,6 @@ class QPD_U(BaseDistribution):
         quantile function value of quantile 0.5
     qv_high : float or array_like[float]
         quantile function value of quantile ``1 - alpha``
-    l : float
-        lower bound of semi-bounded range
-    u : float
-        upper bound of supported range
     version: str
         options are ``normal`` (default) or ``logistic``
     dist_shape: str
@@ -505,14 +503,16 @@ class QPD_U(BaseDistribution):
 
     Example
     -------
-    >>> from skpro.distributions.qpd import QPD_U
+    >>> from skpro.distributions.qpd import QPD_U  # doctest: +SKIP
 
-    >>> qpd = QPD_S(
-    ...         lower=0.2,
-    ...         qv_low=[[1, 2], [3, 4]],
-    ...         qv_median=[[3, 4], [5, 6]],
-    ...         qv_high=[[5, 6], [7, 8]],
-    ...       )
+    >>> qpd = QPD_U(
+    ...         alpha=0.2,
+    ...         qv_low=[1, 2],
+    ...         qv_median=[3, 4],
+    ...         qv_high=[5, 6],
+    ...       )  # doctest: +SKIP
+
+    >>> qpd.mean()  # doctest: +SKIP
     """
 
     _tags = {
@@ -529,7 +529,7 @@ class QPD_U(BaseDistribution):
         qv_median: float or object,
         qv_high: float or object,
         version: Optional[str] = "normal",
-        dist_shape: Optional[float] = 0,
+        dist_shape: Optional[float] = 0.0,
         index=None,
         columns=None,
     ):
@@ -547,26 +547,25 @@ class QPD_U(BaseDistribution):
 
         from cyclic_boosting.quantile_matching import J_QPD_extended_U
 
-        for qv in [alpha, qv_low, qv_median, qv_high]:
-            if isinstance(qv, float):
-                qv = np.array([qv])
+        params = [alpha, qv_low, qv_median, qv_high]
+        for idx, p in enumerate(params):
+            if isinstance(p, float):
+                params[idx] = np.array([p])
             elif (
-                isinstance(qv, tuple)
-                or isinstance(qv, list)
-                or isinstance(qv, np.ndarray)
+                isinstance(p, tuple) or isinstance(p, list) or isinstance(p, np.ndarray)
             ):
-                qv = np.array(qv)
+                params[idx] = np.array(p)
             else:
                 raise ValueError("data type is not float or array_like object")
 
-        shape = self.qv_low.shape
+        alpha, qv_low, qv_median, qv_high = params[:]
         if index is None:
+            index = pd.RangeIndex(qv_low.shape[0])
             self.index = index
-            index = pd.RangeIndex(shape[0])
 
         if columns is None:
+            columns = pd.RangeIndex(1)
             self.columns = columns
-            columns = pd.RangeIndex(shape[1])
 
         if version == "normal":
             self.phi = norm()
@@ -602,7 +601,7 @@ class QPD_U(BaseDistribution):
                 shape=dist_shape,
             )
             self.qpd.append(jqpd)
-        self.qpd = pd.DataFrame(self.qpd, index=index)
+        self.qpd = pd.DataFrame(self.qpd, index=self.index)
 
     def mean(self, lower=0.0, upper=np.inf):
         """Return expected value of the distribution.

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -18,7 +18,7 @@ from cyclic_boosting.quantile_matching import J_QPD_S, J_QPD_B
 
 
 class QPD_S(BaseDistribution):
-    """Johnson Quantile-Parameterized Distributions
+    """Johnson Quantile-Parameterized Distributions with semi-bounded mode
 
     see https://repositories.lib.utexas.edu/bitstream/handle/2152/63037/HADLOCK-DISSERTATION-2017.pdf
     (Due to the Python keyword, the parameter lambda from this reference is named kappa below.).
@@ -106,6 +106,170 @@ class QPD_S(BaseDistribution):
                 qv_median=qv_median[iter.index],
                 qv_high=qv_high[iter.index],
                 l=l,
+                version=version,
+            )
+            self.qpd.append(jqpd)
+        self.qpd = pd.DataFrame(self.qpd, index=index)
+
+        super().__init__(index=index, columns=columns)
+
+    def mean(self, lower=0.0, upper=np.inf):
+        def exp_func(x, qpd):
+            # TODO: scipy.integrate will be removed in scipy 1.12.0
+            pdf = derivative(qpd.cdf, x, dx=1e-6)
+            return x * pdf
+
+        loc = []
+        for idx in self.index:
+            qpd = self.qpd.loc[idx, :].values[0]
+            # NOTE: integral interval should be checked, -inf to inf will be NaN
+            l, _ = quad(exp_func, args=(qpd), a=lower, b=upper)
+            loc.append(l)
+        loc_arr = np.array(loc)
+        return pd.DataFrame(loc_arr, index=self.index, columns=self.columns)
+
+    def var(self, lower=0.0, upper=np.inf):
+        def var_func(x, mu, qpd):
+            # TODO: scipy.integrate will be removed in scipy 1.12.0
+            pdf = derivative(qpd.cdf, x, dx=1e-6)
+            return ((x - mu) ** 2) * pdf
+
+        mean = self.mean()
+        var = []
+        for idx in self.index:
+            mu = mean.loc[idx, :].to_numpy()
+            qpd = self.qpd.loc[idx, :].values[0]
+            # NOTE: integral interval should be checked, -inf to inf will be NaN
+            l, _ = quad(var_func, args=(mu, qpd), a=lower, b=upper)
+            var.append(l)
+        var_arr = np.array(var)
+        return pd.DataFrame(var_arr, index=self.index, columns=self.columns)
+
+    def pdf(self, x: pd.DataFrame):
+        # cdf -> pdf calculation because j-qpd's pdf calculation is bit complex
+        pdf = []
+        for idx in x.index:
+            qpd = self.qpd.loc[idx, :].values[0]
+            _x = x.loc[idx, :]
+            _pdf = [derivative(qpd.cdf, x0, dx=1e-6) for x0 in _x]
+            pdf.append(_pdf)
+        pdf_arr = np.array(pdf)
+        return pd.DataFrame(pdf_arr, index=x.index, columns=x.columns)
+
+    def ppf(self, p: pd.DataFrame):
+        ppf = []
+        for idx in p.index:
+            qpd = self.qpd.loc[idx, :].values[0]
+            _ppf = qpd.ppf(p.loc[idx, :])
+            ppf.append(_ppf)
+        ppf_arr = np.array(ppf)
+        return pd.DataFrame(ppf_arr, index=p.index, columns=p.columns)
+
+    def cdf(self, x: pd.DataFrame):
+        cdf_arr = np.empty_like(x.shape)
+        cdf = []
+        for idx in x.index:
+            qpd = self.qpd.loc[idx, :].values[0]
+            _cdf = qpd.cdf(x.loc[idx, :])
+            cdf.append(_cdf)
+        cdf_arr = np.array(cdf)
+        return pd.DataFrame(cdf_arr, index=x.index, columns=x.columns)
+
+
+class QPD_B(BaseDistribution):
+    """Johnson Quantile-Parameterized Distributions with bounded mode
+
+    see https://repositories.lib.utexas.edu/bitstream/handle/2152/63037/HADLOCK-DISSERTATION-2017.pdf
+    (Due to the Python keyword, the parameter lambda from this reference is named kappa below.).
+    A distribution is parameterized by a symmetric-percentile triplet (SPT).
+
+    Parameters
+    ----------
+    alpha : float
+        lower quantile of SPT (upper is ``1 - alpha``)
+    qv_low : float or array_like[float]
+        quantile function value of ``alpha``
+    qv_median : float or array_like[float]
+        quantile function value of quantile 0.5
+    qv_high : float or array_like[float]
+        quantile function value of quantile ``1 - alpha``
+    l : float
+        lower bound of semi-bounded range
+    u : float
+        upper bound of supported range
+    version: str
+        options are ``normal`` (default) or ``logistic``
+    """
+
+    _tags = {
+        "capabilities:approx": ["pdfnorm"],
+        "capabilities:exact": ["mean", "var", "cdf", "ppf"],
+        "distr:measuretype": "continuous",
+    }
+
+    def __init__(
+        self,
+        alpha: float,
+        qv_low: float or object,
+        qv_median: float or object,
+        qv_high: float or object,
+        l: float,
+        u: float,
+        version: Optional[str] = "normal",
+        index=None,
+        columns=None,
+    ):
+        self.qpd = []
+        self.alpha = alpha
+        self.version = version
+        self.qv_low = qv_low
+        self.qv_median = qv_median
+        self.qv_high = qv_high
+        self.l = l
+        self.u = u
+        self.index = index
+        self.columns = columns
+
+        for qv in [alpha, qv_low, qv_median, qv_high]:
+            if isinstance(qv, float):
+                qv = np.array([qv])
+            elif (
+                isinstance(qv, tuple)
+                or isinstance(qv, list)
+                or isinstance(qv, np.ndarray)
+            ):
+                qv = np.array(qv)
+            else:
+                raise ValueError("data type is not float or array_like object")
+
+        if version == "normal":
+            self.phi = norm()
+        elif version == "logistic":
+            self.phi = logistic()
+        else:
+            raise Exception("Invalid version.")
+
+        if (np.any(qv_low > qv_median)) or np.any((qv_high < qv_median)):
+            warnings.warn(
+                "The SPT values are not monotonically increasing, each SPT will be replaced by mean value"
+            )
+            idx = np.where((qv_low > qv_median), True, False) + np.where(
+                (qv_high < qv_median), True, False
+            )
+            print(f"replaced index by mean {np.argwhere(idx > 0).tolist()}")
+            qv_low[idx] = np.nanmean(qv_low)
+            qv_median[idx] = np.nanmean(qv_median)
+            qv_high[idx] = np.nanmean(qv_high)
+
+        iter = np.nditer(qv_low, flags=["c_index"])
+        for x in iter:
+            jqpd = J_QPD_B(
+                alpha=alpha,
+                qv_low=qv_low[iter.index],
+                qv_median=qv_median[iter.index],
+                qv_high=qv_high[iter.index],
+                l=l,
+                u=u,
                 version=version,
             )
             self.qpd.append(jqpd)

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -124,18 +124,19 @@ class QPD_S(BaseDistribution):
         if (np.any(qv_low > qv_median)) or np.any(qv_high < qv_median):
             warnings.warn(
                 "The SPT values are not monotonically increasing, "
-                "each SPT will be replaced by mean value",
+                "each SPT is sorted by value",
                 stacklevel=2,
             )
             idx = np.where((qv_low > qv_median), True, False) + np.where(
                 (qv_high < qv_median), True, False
             )
-            warnings.warn(
-                f"replaced index by mean {np.argwhere(idx > 0).tolist()}", stacklevel=2
-            )
-            qv_low[idx] = np.nanmean(qv_low)
-            qv_median[idx] = np.nanmean(qv_median)
-            qv_high[idx] = np.nanmean(qv_high)
+            un_orderd_idx = np.argwhere(idx > 0).tolist()
+            warnings.warn(f"sorted index {un_orderd_idx}", stacklevel=2)
+            for idx in un_orderd_idx:
+                low, mid, high = sorted([qv_low[idx], qv_median[idx], qv_high[idx]])
+                qv_low[idx] = low
+                qv_median[idx] = mid
+                qv_high[idx] = high
 
         iter = np.nditer(qv_low, flags=["c_index"])
         for _i in iter:
@@ -195,7 +196,7 @@ class QPD_S(BaseDistribution):
         for idx in x.index:
             qpd = self.qpd.loc[idx, :].values[0]
             _x = x.loc[idx, :]
-            _pdf = [derivative(qpd.cdf, x0, dx=1e-6) for x0 in _x]
+            _pdf = derivative(qpd.cdf, _x, dx=1e-6)
             pdf.append(_pdf)
         pdf_arr = np.array(pdf)
         return pd.DataFrame(pdf_arr, index=x.index, columns=x.columns)
@@ -353,18 +354,19 @@ class QPD_B(BaseDistribution):
         if (np.any(qv_low > qv_median)) or np.any(qv_high < qv_median):
             warnings.warn(
                 "The SPT values are not monotonically increasing, "
-                "each SPT will be replaced by mean value",
+                "each SPT is sorted by value",
                 stacklevel=2,
             )
             idx = np.where((qv_low > qv_median), True, False) + np.where(
                 (qv_high < qv_median), True, False
             )
-            warnings.warn(
-                f"replaced index by mean {np.argwhere(idx > 0).tolist()}", stacklevel=2
-            )
-            qv_low[idx] = np.nanmean(qv_low)
-            qv_median[idx] = np.nanmean(qv_median)
-            qv_high[idx] = np.nanmean(qv_high)
+            un_orderd_idx = np.argwhere(idx > 0).tolist()
+            warnings.warn(f"sorted index {un_orderd_idx}", stacklevel=2)
+            for idx in un_orderd_idx:
+                low, mid, high = sorted([qv_low[idx], qv_median[idx], qv_high[idx]])
+                qv_low[idx] = low
+                qv_median[idx] = mid
+                qv_high[idx] = high
 
         iter = np.nditer(qv_low, flags=["c_index"])
         for _i in iter:
@@ -425,7 +427,7 @@ class QPD_B(BaseDistribution):
         for idx in x.index:
             qpd = self.qpd.loc[idx, :].values[0]
             _x = x.loc[idx, :]
-            _pdf = [derivative(qpd.cdf, x0, dx=1e-6) for x0 in _x]
+            _pdf = derivative(qpd.cdf, _x, dx=1e-6)
             pdf.append(_pdf)
         pdf_arr = np.array(pdf)
         return pd.DataFrame(pdf_arr, index=x.index, columns=x.columns)
@@ -577,18 +579,19 @@ class QPD_U(BaseDistribution):
         if (np.any(qv_low > qv_median)) or np.any(qv_high < qv_median):
             warnings.warn(
                 "The SPT values are not monotonically increasing, "
-                "each SPT will be replaced by mean value",
+                "each SPT is sorted by value",
                 stacklevel=2,
             )
             idx = np.where((qv_low > qv_median), True, False) + np.where(
                 (qv_high < qv_median), True, False
             )
-            warnings.warn(
-                f"replaced index by mean {np.argwhere(idx > 0).tolist()}", stacklevel=2
-            )
-            qv_low[idx] = np.nanmean(qv_low)
-            qv_median[idx] = np.nanmean(qv_median)
-            qv_high[idx] = np.nanmean(qv_high)
+            un_orderd_idx = np.argwhere(idx > 0).tolist()
+            warnings.warn(f"sorted index {un_orderd_idx}", stacklevel=2)
+            for idx in un_orderd_idx:
+                low, mid, high = sorted([qv_low[idx], qv_median[idx], qv_high[idx]])
+                qv_low[idx] = low
+                qv_median[idx] = mid
+                qv_high[idx] = high
 
         iter = np.nditer(qv_low, flags=["c_index"])
         for _i in iter:
@@ -647,7 +650,7 @@ class QPD_U(BaseDistribution):
         for idx in x.index:
             qpd = self.qpd.loc[idx, :].values[0]
             _x = x.loc[idx, :]
-            _pdf = [derivative(qpd.cdf, x0, dx=1e-6) for x0 in _x]
+            _pdf = derivative(qpd.cdf, _x, dx=1e-6)
             pdf.append(_pdf)
         pdf_arr = np.array(pdf)
         return pd.DataFrame(pdf_arr, index=x.index, columns=x.columns)

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -94,7 +94,7 @@ class QPD_S(BaseDistribution):
 
         super().__init__(index=index, columns=columns)
 
-        from cyclic_boosting.quantile_matching import J_QPD_S
+        from cyclic_boosting.quantile_matching import J_QPD_extended_S
 
         for qv in [alpha, qv_low, qv_median, qv_high]:
             if isinstance(qv, float):
@@ -321,7 +321,7 @@ class QPD_B(BaseDistribution):
 
         super().__init__(index=index, columns=columns)
         
-        from cyclic_boosting.quantile_matching import J_QPD_B
+        from cyclic_boosting.quantile_matching import J_QPD_extended_B
 
         for qv in [alpha, qv_low, qv_median, qv_high]:
             if isinstance(qv, float):
@@ -545,6 +545,10 @@ class QPD_U(BaseDistribution):
         self.index = index
         self.columns = columns
 
+        super().__init__(index=index, columns=columns)
+
+        from cyclic_boosting.quantile_matching import J_QPD_extended_U
+
         for qv in [alpha, qv_low, qv_median, qv_high]:
             if isinstance(qv, float):
                 qv = np.array([qv])
@@ -601,8 +605,6 @@ class QPD_U(BaseDistribution):
             )
             self.qpd.append(jqpd)
         self.qpd = pd.DataFrame(self.qpd, index=index)
-
-        super().__init__(index=index, columns=columns)
 
     def mean(self, lower=0.0, upper=np.inf):
         """Return expected value of the distribution.

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -25,7 +25,7 @@ class QPD_S(BaseDistribution):
     see https://repositories.lib.utexas.edu/bitstream/handle/2152
         /63037/HADLOCK-DISSERTATION-2017.pdf
     (Due to the Python keyword, the parameter lambda from
-    this reference is named kappa below.).
+    this reference is named kappa below.)
     A distribution is parameterized by a symmetric-percentile triplet (SPT).
 
     Parameters
@@ -48,12 +48,12 @@ class QPD_S(BaseDistribution):
     >>> from skpro.distributions.qpd import QPD_S
 
     >>> qpd = QPD_S(
-                    lower=0.2,
-                    qv_low=[[1, 2], [3, 4]],
-                    qv_median=[[3, 4], [5, 6]],
-                    qv_high=[[5, 6], [7, 8]],
-                    l=0
-              )
+    ...         lower=0.2,
+    ...         qv_low=[[1, 2], [3, 4]],
+    ...         qv_median=[[3, 4], [5, 6]],
+    ...         qv_high=[[5, 6], [7, 8]],
+    ...         l=0
+    ...       )
     """
 
     _tags = {

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -62,6 +62,7 @@ class QPD_S(BaseDistribution):
         "capabilities:approx": [],
         "capabilities:exact": ["mean", "var", "cdf", "ppf"],
         "distr:measuretype": "continuous",
+        "python_dependencies": "cyclic_boosting>=1.2.5",
     }
 
     def __init__(
@@ -287,6 +288,7 @@ class QPD_B(BaseDistribution):
         "capabilities:approx": [],
         "capabilities:exact": ["mean", "var", "cdf", "ppf"],
         "distr:measuretype": "continuous",
+        "python_dependencies": "cyclic_boosting>=1.2.5",
     }
 
     def __init__(
@@ -517,6 +519,7 @@ class QPD_U(BaseDistribution):
         "capabilities:approx": [],
         "capabilities:exact": ["mean", "var", "cdf", "ppf"],
         "distr:measuretype": "continuous",
+        "python_dependencies": "cyclic_boosting>=1.2.5",
     }
 
     def __init__(

--- a/skpro/distributions/tests/test_qpd.py
+++ b/skpro/distributions/tests/test_qpd.py
@@ -1,6 +1,7 @@
 """Tests for quantile-parameterized distributions."""
 
 import pytest
+
 from skpro.distributions.qpd import QPD_B, QPD_S, QPD_U
 from skpro.tests.test_switch import run_test_for_class
 

--- a/skpro/distributions/tests/test_qpd.py
+++ b/skpro/distributions/tests/test_qpd.py
@@ -1,0 +1,62 @@
+"""Tests for quantile-parameterized distributions."""
+
+import pytest
+from skpro.distributions.qpd import QPD_B, QPD_S, QPD_U
+from skpro.tests.test_switch import run_test_for_class
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(QPD_B),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_qpd_b_simple_use():
+    """Test simple use of qpd with bounded mode."""
+    from skpro.distributions.qpd import QPD_B
+
+    qpd = QPD_B(
+        alpha=0.2,
+        qv_low=[1, 2],
+        qv_median=[3, 4],
+        qv_high=[5, 6],
+        lower=0,
+        upper=10,
+    )
+
+    qpd.mean()
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(QPD_S),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_qpd_s_simple_use():
+    """Test simple use of qpd with semi-bounded mode."""
+    from skpro.distributions.qpd import QPD_S
+
+    qpd = QPD_S(
+        alpha=0.2,
+        qv_low=[1, 2],
+        qv_median=[3, 4],
+        qv_high=[5, 6],
+        lower=0,
+    )
+
+    qpd.mean()
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(QPD_U),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_qpd_u_simple_use():
+    """Test simple use of qpd with unbounded mode."""
+    from skpro.distributions.qpd import QPD_U
+
+    qpd = QPD_U(
+        alpha=0.2,
+        qv_low=[1, 2],
+        qv_median=[3, 4],
+        qv_high=[5, 6],
+    )
+
+    qpd.mean()

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -443,6 +443,5 @@ class CyclicBoosting(BaseProbaRegressor):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-
         param1 = {"alpha": 0.3, "mode": "additive", "bound": "S", "lower": 0.0}
         return [param1]

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -257,12 +257,12 @@ class CyclicBoosting(BaseProbaRegressor):
             distr_type = Normal
             distr_loc_scale_name = ("mu", "sigma")
             self.var_jqpd = np.sqrt(self.var_jqpd)
-        # TODO: add other distributions
-        # elif distr_type == "Laplace":
-        #     from skpro.distributions.laplace import Laplace
+        elif distr_type == "Laplace":
+            from skpro.distributions.laplace import Laplace
 
-        #     distr_type = Laplace
-        #     distr_loc_scale_name = ("mu", "scale")
+            distr_type = Laplace
+            distr_loc_scale_name = ("mu", "scale")
+            self.var_jppd = np.sqrt(self.var_jqpd) / 2
         # elif distr_type in ["Cauchy", "t"]:
         #     from skpro.distributions.t import TDistribution
 
@@ -322,10 +322,10 @@ class CyclicBoosting(BaseProbaRegressor):
         }
         param1 = {"feature_properties": fp}
         param2 = {"feature_properties": fp, "interaction": [("age", "sex"), ("s1, s3")]}
-        # param3 = {
-        #     "feature_properties": fp,
-        #     "interaction": [("age", "sex"), ("s1, s3")],
-        #     "distr_type": "Laplace",
-        # }
+        param3 = {
+            "feature_properties": fp,
+            "interaction": [("age", "sex"), ("s1, s3")],
+            "distr_type": "Laplace",
+        }
 
-        return [param1, param2]
+        return [param1, param2, param3]

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -1,0 +1,351 @@
+"""Cyclic boosting regressors.
+This is a interface for Cyclic boosting, it contains efficient,
+off-the-shelf, general-purpose supervised machine learning methods
+for both regression and classification tasks.
+Please read the official document for its detail
+https://cyclic-boosting.readthedocs.io/en/latest/
+"""
+
+"""License.
+EPL 2.0
+https://github.com/Blue-Yonder-OSS/cyclic-boosting/blob/main/LICENSE
+"""
+
+__author__ = ["setoguchi-naoki"]
+
+import numpy as np
+import pandas as pd
+from scipy.misc import derivative
+from scipy.integrate import quad
+from skpro.regression.base import BaseProbaRegressor
+
+# from cyclic_boosting import common_smoothers, binning
+from cyclic_boosting import (
+    pipeline_CBMultiplicativeQuantileRegressor,
+)
+from cyclic_boosting.quantile_matching import J_QPD_S
+
+
+# todo: change class name and write docstring
+class CyclicBoosting(BaseProbaRegressor):
+    """Cyclic boosting regressor.
+
+    Estimates the parameters of Johnson Quantile-Parameterized Distributions
+    (JQPD) by quantile regression, which is one of the Cyclic boosting's functions
+    this method can more accurately approximate to the distribution of observed data
+
+    Parameters
+    ----------
+    feature_properties : dict
+        name and characteristic of train dataset
+        it is able to set multiple characteristic by OR operator
+        e.g. {sample1: IS_CONTINUOUS | IS_LINEAR, sample2: IS_ORDERED}
+        for basic options, see
+        https://cyclic-boosting.readthedocs.io/en/latest/tutorial.html#set-feature-properties
+    interaction : list[tuple], default=(), optional
+        some combinations of explanatory variables, (interaction term)
+        e.g. [(sample1, sample2), (sample1, sample3)]
+    distr_type: str, default='Normal',
+        probability distribution name which is assumed for observation data's
+        distribution
+
+    Attributes
+    ----------
+    estimators_ : list of of skpro regressors
+        clones of regressor in `estimator` fitted in the ensemble
+    quantiles : list, default=[0.2, 0.5, 0.8]
+        targets of quantile prediction for j-qpd's param
+    quantile_values: list
+        quantile prediction results
+    quantile_est: list
+        estimators, each estimator predicts point in the value of quantiles attribute
+
+    Examples
+    --------
+    >>> from skpro.regression.cyclic_boosting import CyclicBoosting
+    >>> from cyclic_boosting import flags
+    >>> from sklearn.datasets import load_diabetes
+    >>> from sklearn.model_selection import train_test_split
+    >>> X, y = load_diabetes(return_X_y=True, as_frame=True)
+    >>> X_train, X_test, y_train, y_test = train_test_split(X, y)
+    >>>
+    >>> fp = {
+    >>>     'age': flags.IS_CONTINUOUS,
+    >>>     'sex': flags.IS_CONTINUOUS,
+    >>>     'bmi': flags.IS_CONTINUOUS,
+    >>>     'bp':  flags.IS_CONTINUOUS,
+    >>>     's1':  flags.IS_CONTINUOUS,
+    >>>     's2':  flags.IS_CONTINUOUS,
+    >>>     's3':  flags.IS_CONTINUOUS,
+    >>>     's4':  flags.IS_CONTINUOUS,
+    >>>     's5':  flags.IS_CONTINUOUS,
+    >>>     's6':  flags.IS_CONTINUOUS,
+    >>> }
+    >>> reg_proba = CyclicBoosting(feature_properties=fp)
+    >>> reg_proba.fit(X_train, y_train)
+    >>> y_pred = reg_proba.predict_proba(X_test)
+    """
+
+    _tags = {
+        "object_type": "distribution",
+        "estimator_type": "regressor_proba",
+        "capability:multioutput": False,
+        "capability:missing": True,
+        "X_inner_mtype": "pd_DataFrame_Table",
+        "y_inner_mtype": "pd_DataFrame_Table",
+    }
+
+    def __init__(self, feature_properties, interaction=tuple(), distr_type="Normal"):
+        self.feature_properties = feature_properties
+        self.interaction = interaction
+        self.quantiles = [0.2, 0.5, 0.8]
+        self.quantile_values = []
+        self.quantile_est = []
+        self.mean_jqpd = None
+        self.var_jqpd = None
+        self.distr_type = distr_type
+
+        super().__init__()
+
+        # check parameters
+        if not isinstance(feature_properties, dict):
+            raise ValueError("feature_properties must be dict")
+        for i in interaction:
+            if not isinstance(i, tuple):
+                raise ValueError("interaction must be tuple")
+
+        # build estimators
+        features = list(self.feature_properties.keys())
+        for i in interaction:
+            features.append(i)
+
+        for quantile in self.quantiles:
+            self.quantile_est.append(
+                pipeline_CBMultiplicativeQuantileRegressor(
+                    quantile=quantile,
+                    feature_properties=self.feature_properties,
+                    feature_groups=features,
+                    maximal_iterations=100,
+                )
+            )
+
+    def _fit(self, X, y):
+        """Fit regressor to training data.
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        X : pandas DataFrame
+            feature instances to fit regressor to
+        y : pandas DataFrame, must be same length as X
+            labels to fit regressor to
+
+        Returns
+        -------
+        self : reference to self
+        """
+
+        self._y_cols = y.columns
+        y = y.to_numpy().flatten()
+
+        # multiple quantile regression for full probability estimation
+        for est in self.quantile_est:
+            est.fit(X.copy(), y)
+
+        return self
+
+    def _predict(self, X):
+        """Predict labels for data from features.
+
+        State required:
+            Requires state to be "fitted" = self.is_fitted=True
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+
+        Parameters
+        ----------
+        X : pandas DataFrame, must have same columns as X in `fit`
+            data to predict labels for
+
+        Returns
+        -------
+        y : pandas DataFrame, same length as `X`, same columns as `y` in `fit`
+            labels predicted for `X`
+        """
+
+        index = X.index
+        y_cols = self._y_cols
+        columns = y_cols
+
+        # quantile prediction
+        for est in self.quantile_est:
+            yhat = est.predict(X.copy())
+            self.quantile_values.append(yhat)
+
+        # generate j-qpd on each sample
+        mean, var = [], []
+        n_samples = len(X)
+
+        # NOTE: cdf -> pdf calculation because j-qpd's pdf calculation is bit complex
+        def exp_func(x):
+            pdf = derivative(j_qpd_s.cdf, x, dx=1e-6)
+            return x * pdf
+
+        def var_func(x, mu):
+            pdf = derivative(j_qpd_s.cdf, x, dx=1e-6)
+            return ((x - mu) ** 2) * pdf
+
+        for i in range(n_samples):
+            try:
+                j_qpd_s = J_QPD_S(
+                    0.2,
+                    self.quantile_values[0][i],
+                    self.quantile_values[1][i],
+                    self.quantile_values[2][i],
+                )
+                # TODO: scipy.integrate will be removed in scipy 1.12.0
+                # NOTE: integral range (-inf to inf) return NaN, it should check
+                loc, _ = quad(exp_func, a=0.0, b=np.inf)
+                mean.append(loc)
+                scale, _ = quad(var_func, a=0.0, b=np.inf, args=(loc))
+                var.append(scale)
+            except ValueError:
+                mean.append(np.nan)
+                var.append(np.nan)
+                continue
+
+        # fill nan by mean
+        mean_arr = np.asarray(mean)
+        mean_arr[np.isnan(mean_arr)] = np.nanmean(mean_arr)
+        var_arr = np.asarray(var)
+        var_arr[np.isnan(var_arr)] = np.nanmean(var_arr)
+        self.mean_jqpd = mean_arr.reshape(-1, len(y_cols))
+        self.var_jqpd = var_arr.reshape(-1, len(y_cols))
+
+        y_pred = pd.DataFrame(mean, index=index, columns=columns)
+        return y_pred
+
+    def _predict_proba(self, X):
+        """Predict distribution over labels for data from features.
+
+        State required:
+            Requires state to be "fitted".
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+
+        Parameters
+        ----------
+        X : pandas DataFrame, must have same columns as X in `fit`
+            data to predict labels for
+
+        Returns
+        -------
+        y_pred : skpro BaseDistribution, same length as `X`
+            labels predicted for `X`
+        """
+
+        # mean, variance calculation from j-qpd
+        _ = self._predict(X)
+
+        if self.distr_type == "Normal":
+            from skpro.distributions.normal import Normal
+
+            distr_type = Normal
+            distr_loc_scale_name = ("mu", "sigma")
+            self.var_jqpd = np.sqrt(self.var_jqpd)
+        # TODO: add other distributions
+        # elif distr_type == "Laplace":
+        #     from skpro.distributions.laplace import Laplace
+
+        #     distr_type = Laplace
+        #     distr_loc_scale_name = ("mu", "scale")
+        # elif distr_type in ["Cauchy", "t"]:
+        #     from skpro.distributions.t import TDistribution
+
+        #     distr_type = TDistribution
+        #     distr_loc_scale_name = ("mu", "sigma")
+        else:
+            raise NotImplementedError(f"{self.distr_type} is not support")
+
+        params = {}
+        # row/column index
+        ix = {"index": X.index, "columns": self._y_cols}
+        params.update(ix)
+        # location and scale
+        loc_scale = {
+            distr_loc_scale_name[0]: self.mean_jqpd,
+            distr_loc_scale_name[1]: self.var_jqpd,
+        }
+        params.update(loc_scale)
+
+        y_pred = distr_type(**params)
+        return y_pred
+
+    # todo: return default parameters, so that a test instance can be created
+    #   required for automated unit and integration testing of estimator
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+
+        # todo: set the testing parameters for the estimators
+        # Testing parameters can be dictionary or list of dictionaries
+        #
+        # this can, if required, use:
+        #   class properties (e.g., inherited); parent class test case
+        #   imported objects such as estimators from skpro or sklearn
+        # important: all such imports should be *inside get_test_params*, not at the top
+        #            since imports are used only at testing time
+        #
+        # The parameter_set argument is not used for most automated, module level tests.
+        #   It can be used in custom, estimator specific tests, for "special" settings.
+        #   For classification, this is also used in tests for reference settings,
+        #       such as published in benchmarking studies, or for identity testing.
+        # A parameter dictionary must be returned *for all values* of parameter_set,
+        #   i.e., "parameter_set not available" errors should never be raised.
+        #
+        # A good parameter set should primarily satisfy two criteria,
+        #   1. Chosen set of parameters should have a low testing time,
+        #      ideally in the magnitude of few seconds for the entire test suite.
+        #       This is vital for the cases where default values result in
+        #       "big" models which not only increases test time but also
+        #       run into the risk of test workers crashing.
+        #   2. There should be a minimum two such parameter sets with different
+        #      sets of values to ensure a wide range of code coverage is provided.
+        #
+        # example 1: specify params as dictionary
+        # any number of params can be specified
+        # params = {"est": value0, "parama": value1, "paramb": value2}
+        #
+        # example 2: specify params as list of dictionary
+        # note: Only first dictionary will be used by create_test_instance
+        # params = [{"est": value1, "parama": value2},
+        #           {"est": value3, "parama": value4}]
+        #
+        # example 3: parameter set depending on param_set value
+        #   note: only needed if a separate parameter set is needed in tests
+        # if parameter_set == "special_param_set":
+        #     params = {"est": value1, "parama": value2}
+        #     return params
+        #
+        # # "default" params
+        # params = {"est": value3, "parama": value4}
+        # return params

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -305,47 +305,27 @@ class CyclicBoosting(BaseProbaRegressor):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
+        from cyclic_boosting import flags
 
-        # todo: set the testing parameters for the estimators
-        # Testing parameters can be dictionary or list of dictionaries
-        #
-        # this can, if required, use:
-        #   class properties (e.g., inherited); parent class test case
-        #   imported objects such as estimators from skpro or sklearn
-        # important: all such imports should be *inside get_test_params*, not at the top
-        #            since imports are used only at testing time
-        #
-        # The parameter_set argument is not used for most automated, module level tests.
-        #   It can be used in custom, estimator specific tests, for "special" settings.
-        #   For classification, this is also used in tests for reference settings,
-        #       such as published in benchmarking studies, or for identity testing.
-        # A parameter dictionary must be returned *for all values* of parameter_set,
-        #   i.e., "parameter_set not available" errors should never be raised.
-        #
-        # A good parameter set should primarily satisfy two criteria,
-        #   1. Chosen set of parameters should have a low testing time,
-        #      ideally in the magnitude of few seconds for the entire test suite.
-        #       This is vital for the cases where default values result in
-        #       "big" models which not only increases test time but also
-        #       run into the risk of test workers crashing.
-        #   2. There should be a minimum two such parameter sets with different
-        #      sets of values to ensure a wide range of code coverage is provided.
-        #
-        # example 1: specify params as dictionary
-        # any number of params can be specified
-        # params = {"est": value0, "parama": value1, "paramb": value2}
-        #
-        # example 2: specify params as list of dictionary
-        # note: Only first dictionary will be used by create_test_instance
-        # params = [{"est": value1, "parama": value2},
-        #           {"est": value3, "parama": value4}]
-        #
-        # example 3: parameter set depending on param_set value
-        #   note: only needed if a separate parameter set is needed in tests
-        # if parameter_set == "special_param_set":
-        #     params = {"est": value1, "parama": value2}
-        #     return params
-        #
-        # # "default" params
-        # params = {"est": value3, "parama": value4}
-        # return params
+        # NOTE: This test is only corresponded diabeat dataset
+        fp = {
+            "age": flags.IS_CONTINUOUS,
+            "sex": flags.IS_CONTINUOUS,
+            "bmi": flags.IS_CONTINUOUS,
+            "bp": flags.IS_CONTINUOUS,
+            "s1": flags.IS_CONTINUOUS,
+            "s2": flags.IS_CONTINUOUS,
+            "s3": flags.IS_CONTINUOUS,
+            "s4": flags.IS_CONTINUOUS,
+            "s5": flags.IS_CONTINUOUS,
+            "s6": flags.IS_CONTINUOUS,
+        }
+        param1 = {"feature_properties": fp}
+        param2 = {"feature_properties": fp, "interaction": [("age", "sex"), ("s1, s3")]}
+        # param3 = {
+        #     "feature_properties": fp,
+        #     "interaction": [("age", "sex"), ("s1, s3")],
+        #     "distr_type": "Laplace",
+        # }
+
+        return [param1, param2]

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -1,4 +1,5 @@
 """Cyclic boosting regressors.
+
 This is a interface for Cyclic boosting, it contains efficient,
 off-the-shelf, general-purpose supervised machine learning methods
 for both regression and classification tasks.
@@ -12,19 +13,19 @@ __author__ = [
 ]  # interface only. Cyclic boosting authors in cyclic_boosting package
 
 import warnings
+
 import numpy as np
 import pandas as pd
-from skpro.regression.base import BaseProbaRegressor
-from skpro.distributions.qpd import QPD_S
 
-# from cyclic_boosting import common_smoothers, binning
 from cyclic_boosting import (
-    pipeline_CBMultiplicativeQuantileRegressor,
     pipeline_CBAdditiveQuantileRegressor,
+    pipeline_CBMultiplicativeQuantileRegressor,
 )
 
+from skpro.distributions.qpd import QPD_S
+from skpro.regression.base import BaseProbaRegressor
 
-# todo: change class name and write docstring
+
 class CyclicBoosting(BaseProbaRegressor):
     """Cyclic boosting regressor.
 
@@ -163,7 +164,6 @@ class CyclicBoosting(BaseProbaRegressor):
         -------
         self : reference to self
         """
-
         self._y_cols = y.columns
         y = y.to_numpy().flatten()
 
@@ -192,7 +192,6 @@ class CyclicBoosting(BaseProbaRegressor):
         y : pandas DataFrame, same length as `X`, same columns as `y` in `fit`
             labels predicted for `X`
         """
-
         index = X.index
         y_cols = self._y_cols
 
@@ -222,7 +221,6 @@ class CyclicBoosting(BaseProbaRegressor):
         y_pred : skpro BaseDistribution, same length as `X`
             labels predicted for `X`
         """
-
         index = X.index
         y_cols = self._y_cols
 
@@ -271,7 +269,6 @@ class CyclicBoosting(BaseProbaRegressor):
             Upper/lower interval end are equivalent to
             quantile predictions at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
-
         index = X.index
         y_cols = self._y_cols
         columns = pd.MultiIndex.from_product(
@@ -311,7 +308,6 @@ class CyclicBoosting(BaseProbaRegressor):
             Entries are quantile predictions, for var in col index,
                 at quantile probability in second col index, for the row index.
         """
-
         is_given_proba = False
         warning = (
             "{} percentile doesn't trained, return QPD's quantile value, "
@@ -322,11 +318,11 @@ class CyclicBoosting(BaseProbaRegressor):
         if isinstance(alpha, list):
             for a in alpha:
                 if not (a in self.quantiles):
-                    warnings.warn(warning.format(a))
+                    warnings.warn(warning.format(a), stacklevel=2)
                     is_given_proba = True
         elif isinstance(alpha, float):
             if not (alpha in self.quantiles):
-                warnings.warn(warning.format(alpha))
+                warnings.warn(warning.format(alpha), stacklevel=2)
                 is_given_proba = True
         else:
             raise ValueError("alpha must be float or list of floats")

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -16,13 +16,12 @@ import warnings
 
 import numpy as np
 import pandas as pd
-
 from cyclic_boosting import (
     pipeline_CBAdditiveQuantileRegressor,
     pipeline_CBMultiplicativeQuantileRegressor,
 )
 
-from skpro.distributions.qpd import QPD_S
+from skpro.distributions.qpd import QPD_S, QPD_B, QPD_U
 from skpro.regression.base import BaseProbaRegressor
 
 
@@ -48,6 +47,14 @@ class CyclicBoosting(BaseProbaRegressor):
         lower quantile for QPD's parameter alpha
     mode : str, default='multiplicative'
         the type of quantile regressor. 'multiplicative' or 'additive'
+    bound : str
+            Different modes defined by supported target range, options are ``S``
+            (semi-bound), ``B`` (bound), and ``U`` (unbound).
+    lower : float
+        lower bound of supported range (only active for bound and semi-bound
+        modes)
+    upper : float
+        upper bound of supported range (only active for bound mode)
 
     Attributes
     ----------
@@ -104,6 +111,9 @@ class CyclicBoosting(BaseProbaRegressor):
         interaction=tuple(),
         alpha=0.2,
         mode="multiplicative",
+        bound="U",
+        lower=0,
+        upper=1,
     ):
         self.feature_properties = feature_properties
         self.interaction = interaction
@@ -113,17 +123,20 @@ class CyclicBoosting(BaseProbaRegressor):
         self.quantile_est = []
         self.qpd = None
         self.mode = mode
+        self.bound = bound
+        self.lower = lower
+        self.upper = upper
 
         super().__init__()
 
         # check parameters
         if not isinstance(feature_properties, dict):
-            raise ValueError("feature_properties must be dict")
+            raise ValueError("feature_properties needs to be dict")
         for i in interaction:
             if not isinstance(i, tuple):
-                raise ValueError("interaction must be tuple")
+                raise ValueError("interaction needs to be tuple")
         if alpha >= 0.5 or alpha <= 0.0:
-            raise ValueError("alpha's range must be 0.0 < alpha < 0.5")
+            raise ValueError("alpha's range needs to be 0.0 < alpha < 0.5")
 
         # build estimators
         features = list(self.feature_properties.keys())
@@ -135,7 +148,7 @@ class CyclicBoosting(BaseProbaRegressor):
         elif self.mode == "additive":
             regressor = pipeline_CBAdditiveQuantileRegressor
         else:
-            raise ValueError("mode must be 'multiplicative' or 'additive'")
+            raise ValueError("mode needs to be 'multiplicative' or 'additive'")
 
         for quantile in self.quantiles:
             self.quantile_est.append(
@@ -231,14 +244,25 @@ class CyclicBoosting(BaseProbaRegressor):
             self.quantile_values.append(yhat)
 
         # Johnson Quantile-Parameterized Distributions
-        qpd = QPD_S(
-            alpha=self.alpha,
-            qv_low=self.quantile_values[0],
-            qv_median=self.quantile_values[1],
-            qv_high=self.quantile_values[2],
-            index=index,
-            columns=y_cols,
-        )
+        params = {
+            "alpha": self.alpha,
+            "qv_low": self.quantile_values[0],
+            "qv_median": self.quantile_values[1],
+            "qv_high": self.quantile_values[2],
+            "index": index,
+            "columns": y_cols,
+        }
+        if self.bound == "U":
+            qpd = QPD_U(**params)
+        elif self.bound == "S":
+            params["lower"] = self.lower
+            qpd = QPD_S(**params)
+        elif self.bound == "B":
+            params["lower"] = self.lower
+            params["upper"] = self.upper
+            qpd = QPD_B(**params)
+        else:
+            raise ValueError("bound need to be 'U' or 'S' or 'B'")
 
         return qpd
 
@@ -286,7 +310,7 @@ class CyclicBoosting(BaseProbaRegressor):
 
         return interval
 
-    def _predict_quantiles(self, X, alpha):
+    def _predict_quantiles(self, X, quantiles):
         """Compute/return quantile predictions.
 
         private _predict_quantiles containing the core logic,
@@ -296,7 +320,7 @@ class CyclicBoosting(BaseProbaRegressor):
         ----------
         X : pandas DataFrame, must have same columns as X in `fit`
             data to predict labels for
-        alpha : guaranteed list of float
+        quantiles : guaranteed list of float
             A list of probabilities at which quantile predictions are computed.
 
         Returns
@@ -315,33 +339,33 @@ class CyclicBoosting(BaseProbaRegressor):
             "if you need more plausible quantile value, "
             "please train regressor again for specified quantile estimation"
         )
-        if isinstance(alpha, list):
-            for a in alpha:
-                if not (a in self.quantiles):
-                    warnings.warn(warning.format(a), stacklevel=2)
+        if isinstance(quantiles, list):
+            for q in quantiles:
+                if not (q in self.quantiles):
+                    warnings.warn(warning.format(q), stacklevel=2)
                     is_given_proba = True
-        elif isinstance(alpha, float):
-            if not (alpha in self.quantiles):
-                warnings.warn(warning.format(alpha), stacklevel=2)
+        elif isinstance(quantiles, float):
+            if not (quantiles in self.quantiles):
+                warnings.warn(warning.format(quantiles), stacklevel=2)
                 is_given_proba = True
         else:
-            raise ValueError("alpha must be float or list of floats")
+            raise ValueError("quantile needs to be float or list of floats")
 
         index = X.index
         y_cols = self._y_cols
 
         columns = pd.MultiIndex.from_product(
-            [y_cols, alpha],
+            [y_cols, quantiles],
         )
 
         # predict quantiles
         self.quantile_values = []
         if is_given_proba:
             qpd = self.predict_proba(X.copy())
-            if isinstance(alpha, list):
-                alpha = [alpha]
+            if isinstance(quantiles, list):
+                quantile = [quantiles]
 
-            p = pd.DataFrame(alpha, index=X.index, columns=columns)
+            p = pd.DataFrame(quantile, index=X.index, columns=columns)
             quantiles = qpd.ppf(p)
 
         else:

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -96,13 +96,12 @@ class CyclicBoosting(BaseProbaRegressor):
     """
 
     _tags = {
-        "object_type": "regressor",
         "estimator_type": "regressor_proba",
         "capability:multioutput": False,
         "capability:missing": True,
         "X_inner_mtype": "pd_DataFrame_Table",
         "y_inner_mtype": "pd_DataFrame_Table",
-        "python_dependencies": "cyclic_boosting>=1.2.4",
+        "python_dependencies": "cyclic_boosting>=1.2.5",
     }
 
     def __init__(

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -17,14 +17,7 @@ import pandas as pd
 from skpro.regression.base import BaseProbaRegressor
 from skpro.distributions.qpd import QPD_S
 
-# from cyclic_boosting import common_smoothers, binning
-from cyclic_boosting import (
-    pipeline_CBMultiplicativeQuantileRegressor,
-    pipeline_CBAdditiveQuantileRegressor,
-)
 
-
-# todo: change class name and write docstring
 class CyclicBoosting(BaseProbaRegressor):
     """Cyclic boosting regressor.
 
@@ -130,8 +123,12 @@ class CyclicBoosting(BaseProbaRegressor):
             features.append(i)
 
         if self.mode == "multiplicative":
+            from cyclic_boosting import pipeline_CBMultiplicativeQuantileRegressor
+
             regressor = pipeline_CBMultiplicativeQuantileRegressor
         elif self.mode == "additive":
+            from cyclic_boosting import pipeline_CBAdditiveQuantileRegressor
+
             regressor = pipeline_CBAdditiveQuantileRegressor
         else:
             raise ValueError("mode must be 'multiplicative' or 'additive'")

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -17,7 +17,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from skpro.distributions.qpd import QPD_S, QPD_B, QPD_U
+from skpro.distributions.qpd import QPD_B, QPD_S, QPD_U
 from skpro.regression.base import BaseProbaRegressor
 
 

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -62,7 +62,7 @@ class CyclicBoosting(BaseProbaRegressor):
     qpd: skpro.distributions.J_QPD_S
         Johnson Quantile-Parameterized Distributions instance
 
-    Examples
+    Example
     --------
     >>> from skpro.regression.cyclic_boosting import CyclicBoosting
     >>> from cyclic_boosting import flags
@@ -72,17 +72,17 @@ class CyclicBoosting(BaseProbaRegressor):
     >>> X_train, X_test, y_train, y_test = train_test_split(X, y)
     >>>
     >>> fp = {
-    >>>     'age': flags.IS_CONTINUOUS,
-    >>>     'sex': flags.IS_CONTINUOUS,
-    >>>     'bmi': flags.IS_CONTINUOUS,
-    >>>     'bp':  flags.IS_CONTINUOUS,
-    >>>     's1':  flags.IS_CONTINUOUS,
-    >>>     's2':  flags.IS_CONTINUOUS,
-    >>>     's3':  flags.IS_CONTINUOUS,
-    >>>     's4':  flags.IS_CONTINUOUS,
-    >>>     's5':  flags.IS_CONTINUOUS,
-    >>>     's6':  flags.IS_CONTINUOUS,
-    >>> }
+    ...     'age': flags.IS_CONTINUOUS,
+    ...     'sex': flags.IS_CONTINUOUS,
+    ...     'bmi': flags.IS_CONTINUOUS,
+    ...     'bp':  flags.IS_CONTINUOUS,
+    ...     's1':  flags.IS_CONTINUOUS,
+    ...     's2':  flags.IS_CONTINUOUS,
+    ...     's3':  flags.IS_CONTINUOUS,
+    ...     's4':  flags.IS_CONTINUOUS,
+    ...     's5':  flags.IS_CONTINUOUS,
+    ...     's6':  flags.IS_CONTINUOUS,
+    ... }
     >>> reg_proba = CyclicBoosting(feature_properties=fp)
     >>> reg_proba.fit(X_train, y_train)
     >>> y_pred = reg_proba.predict_proba(X_test)
@@ -95,7 +95,7 @@ class CyclicBoosting(BaseProbaRegressor):
         "capability:missing": True,
         "X_inner_mtype": "pd_DataFrame_Table",
         "y_inner_mtype": "pd_DataFrame_Table",
-        "python_dependencies": "cyclic_boosting>=1.2.1",
+        "python_dependencies": "cyclic_boosting>=1.2.4",
     }
 
     def __init__(

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -89,12 +89,13 @@ class CyclicBoosting(BaseProbaRegressor):
     """
 
     _tags = {
-        "object_type": "distribution",
+        "object_type": "regressor",
         "estimator_type": "regressor_proba",
         "capability:multioutput": False,
         "capability:missing": True,
         "X_inner_mtype": "pd_DataFrame_Table",
         "y_inner_mtype": "pd_DataFrame_Table",
+        "python_dependencies": "cyclic_boosting>=1.2.1",
     }
 
     def __init__(self, feature_properties, interaction=tuple(), distr_type="Normal"):

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -38,9 +38,9 @@ class CyclicBoosting(BaseProbaRegressor):
         e.g. [sample1, sample2, sample3, (sample1, sample2)]
         see https://cyclic-boosting.readthedocs.io/en/latest/tutorial.html#set-features
     feature_properties : dict, default=None
-        name and characteristic of train dataset
+        name and characteristic of train dataset by `flags` from cyclic boosting library
         it is able to set multiple characteristic by OR operator
-        e.g. {sample1: IS_CONTINUOUS | IS_LINEAR, sample2: IS_ORDERED}
+        e.g. {sample1: flags.IS_CONTINUOUS | flags.IS_LINEAR, sample2: flags.IS_ORDERED}
         for basic options, see https://cyclic-boosting.readthedocs.io/en/latest/\
         tutorial.html#set-feature-properties
     alpha : float, default=0.2

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -73,7 +73,7 @@ class CyclicBoosting(BaseProbaRegressor):
     >>> from sklearn.model_selection import train_test_split  # doctest: +SKIP
     >>> X, y = load_diabetes(return_X_y=True, as_frame=True)  # doctest: +SKIP
     >>> X_train, X_test, y_train, y_test = train_test_split(X, y)  # doctest: +SKIP
-    >>>
+
     >>> fp = {
     ...     'age': flags.IS_CONTINUOUS,
     ...     'sex': flags.IS_CONTINUOUS,
@@ -128,17 +128,17 @@ class CyclicBoosting(BaseProbaRegressor):
         if not isinstance(feature_properties, dict):
             raise ValueError("feature_properties needs to be dict")
         if interaction is None:
-            interaction = [()]
-        for i in interaction:
-            if not isinstance(i, tuple):
-                raise ValueError("interaction needs to be tuple")
+            interaction = []
+        if interaction:
+            for i in interaction:
+                if not isinstance(i, tuple):
+                    raise ValueError("interaction needs to be tuple")
         if alpha >= 0.5 or alpha <= 0.0:
             raise ValueError("alpha's range needs to be 0.0 < alpha < 0.5")
 
         # build estimators
         features = list(self.feature_properties.keys())
-        for i in interaction:
-            features.append(i)
+        features += interaction
 
         if self.mode == "multiplicative":
             from cyclic_boosting import pipeline_CBMultiplicativeQuantileRegressor
@@ -414,17 +414,11 @@ class CyclicBoosting(BaseProbaRegressor):
             "s6": flags.IS_CONTINUOUS,
         }
         param1 = {"feature_properties": fp}
-        param2 = {"feature_properties": fp, "interaction": [("age", "sex"), ("s1, s3")]}
-        param3 = {
-            "feature_properties": fp,
-            "interaction": [("age", "sex")],
-            "alpha": 0.3,
-        }
-        param4 = {
+        param2 = {
             "feature_properties": fp,
             "interaction": [("age", "sex")],
             "alpha": 0.3,
             "mode": "additive",
         }
 
-        return [param1, param2, param3, param4]
+        return [param1, param2]

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -68,11 +68,11 @@ class CyclicBoosting(BaseProbaRegressor):
     Example
     --------
     >>> from skpro.regression.cyclic_boosting import CyclicBoosting
-    >>> from cyclic_boosting import flags
-    >>> from sklearn.datasets import load_diabetes
-    >>> from sklearn.model_selection import train_test_split
-    >>> X, y = load_diabetes(return_X_y=True, as_frame=True)
-    >>> X_train, X_test, y_train, y_test = train_test_split(X, y)
+    >>> from cyclic_boosting import flags  # doctest: +SKIP
+    >>> from sklearn.datasets import load_diabetes  # doctest: +SKIP
+    >>> from sklearn.model_selection import train_test_split  # doctest: +SKIP
+    >>> X, y = load_diabetes(return_X_y=True, as_frame=True)  # doctest: +SKIP
+    >>> X_train, X_test, y_train, y_test = train_test_split(X, y)  # doctest: +SKIP
     >>>
     >>> fp = {
     ...     'age': flags.IS_CONTINUOUS,
@@ -85,10 +85,10 @@ class CyclicBoosting(BaseProbaRegressor):
     ...     's4':  flags.IS_CONTINUOUS,
     ...     's5':  flags.IS_CONTINUOUS,
     ...     's6':  flags.IS_CONTINUOUS,
-    ... }
-    >>> reg_proba = CyclicBoosting(feature_properties=fp)
-    >>> reg_proba.fit(X_train, y_train)
-    >>> y_pred = reg_proba.predict_proba(X_test)
+    ... }  # doctest: +SKIP
+    >>> reg_proba = CyclicBoosting(feature_properties=fp)  # doctest: +SKIP
+    >>> reg_proba.fit(X_train, y_train)  # doctest: +SKIP
+    >>> y_pred = reg_proba.predict_proba(X_test)  # doctest: +SKIP
     """
 
     _tags = {

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -36,7 +36,7 @@ class CyclicBoosting(BaseProbaRegressor):
         e.g. {sample1: IS_CONTINUOUS | IS_LINEAR, sample2: IS_ORDERED}
         for basic options, see
         https://cyclic-boosting.readthedocs.io/en/latest/tutorial.html#set-feature-properties
-    interaction : list[tuple], default=(), optional
+    interaction : list[tuple], default=None, optional
         some combinations of explanatory variables, (interaction term)
         e.g. [(sample1, sample2), (sample1, sample3)]
     alpha : float, default=0.2
@@ -103,7 +103,7 @@ class CyclicBoosting(BaseProbaRegressor):
     def __init__(
         self,
         feature_properties,
-        interaction=tuple(),
+        interaction=None,
         alpha=0.2,
         mode="multiplicative",
         bound="U",
@@ -127,6 +127,8 @@ class CyclicBoosting(BaseProbaRegressor):
         # check parameters
         if not isinstance(feature_properties, dict):
             raise ValueError("feature_properties needs to be dict")
+        if interaction is None:
+            interaction = [()]
         for i in interaction:
             if not isinstance(i, tuple):
                 raise ValueError("interaction needs to be tuple")

--- a/skpro/regression/tests/test_cyclic_boosting.py
+++ b/skpro/regression/tests/test_cyclic_boosting.py
@@ -16,12 +16,33 @@ def test_cyclic_boosting_simple_use():
     from sklearn.datasets import load_diabetes
     from sklearn.model_selection import train_test_split
 
-    from skpro.regression.cyclic_boosting import CyclicBoosting
+    X, y = load_diabetes(return_X_y=True, as_frame=True)
+    y = pd.DataFrame(y)
+    X = X.iloc[:200]
+    y = y.iloc[:200]
+    X_train, X_test, y_train, y_test = train_test_split(X, y)
+
+    reg_proba = CyclicBoosting()
+    reg_proba.fit(X_train, y_train)
+    y_pred = reg_proba.predict_proba(X_test)
+
+    assert y_pred.shape == y_test.shape
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(CyclicBoosting),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_cyclic_boosting_with_manual_paramaters():
+    """Test use of cyclic boosting regressor with_manual_paramaters."""
+    from cyclic_boosting import flags
+    from sklearn.datasets import load_diabetes
+    from sklearn.model_selection import train_test_split
 
     X, y = load_diabetes(return_X_y=True, as_frame=True)
     y = pd.DataFrame(y)
-    X = X.iloc[:50]
-    y = y.iloc[:50]
+    X = X.iloc[:200]
+    y = y.iloc[:200]
     X_train, X_test, y_train, y_test = train_test_split(X, y)
 
     features = [
@@ -38,7 +59,28 @@ def test_cyclic_boosting_simple_use():
         ("age", "sex"),
     ]
 
-    reg_proba = CyclicBoosting(feature_groups=features)
+    fp = {
+        "age": flags.IS_CONTINUOUS,
+        "sex": flags.IS_CONTINUOUS,
+        "bmi": flags.IS_CONTINUOUS,
+        "bp": flags.IS_CONTINUOUS,
+        "s1": flags.IS_CONTINUOUS,
+        "s2": flags.IS_CONTINUOUS,
+        "s3": flags.IS_CONTINUOUS,
+        "s4": flags.IS_CONTINUOUS,
+        "s5": flags.IS_CONTINUOUS,
+        "s6": flags.IS_CONTINUOUS,
+    }
+
+    reg_proba = CyclicBoosting(
+        feature_groups=features,
+        feature_properties=fp,
+        maximal_iterations=20,
+        alpha=0.25,
+        mode="additive",
+        bound="S",
+        lower=0.0,
+    )
     reg_proba.fit(X_train, y_train)
     y_pred = reg_proba.predict_proba(X_test)
 

--- a/skpro/regression/tests/test_cyclic_boosting.py
+++ b/skpro/regression/tests/test_cyclic_boosting.py
@@ -21,6 +21,8 @@ def test_cyclic_boosting_simple_use():
 
     X, y = load_diabetes(return_X_y=True, as_frame=True)
     y = pd.DataFrame(y)
+    X = X.iloc[:50]
+    y = y.iloc[:50]
     X_train, X_test, y_train, y_test = train_test_split(X, y)
 
     fp = {
@@ -37,7 +39,7 @@ def test_cyclic_boosting_simple_use():
     }
 
     reg_proba = CyclicBoosting(feature_properties=fp)
-    reg_proba.fit(X_train.copy(), y_train)
+    reg_proba.fit(X_train, y_train)
     y_pred = reg_proba.predict_proba(X_test)
 
     assert y_pred.shape == y_test.shape

--- a/skpro/regression/tests/test_cyclic_boosting.py
+++ b/skpro/regression/tests/test_cyclic_boosting.py
@@ -37,7 +37,7 @@ def test_cyclic_boosting_simple_use():
     }
 
     reg_proba = CyclicBoosting(feature_properties=fp)
-    reg_proba.fit(X_train, y_train)
+    reg_proba.fit(X_train.copy(), y_train)
     y_pred = reg_proba.predict_proba(X_test)
 
     assert y_pred.shape == y_test.shape

--- a/skpro/regression/tests/test_cyclic_boosting.py
+++ b/skpro/regression/tests/test_cyclic_boosting.py
@@ -75,7 +75,7 @@ def test_cyclic_boosting_with_manual_paramaters():
     reg_proba = CyclicBoosting(
         feature_groups=features,
         feature_properties=fp,
-        maximal_iterations=20,
+        maximal_iterations=5,
         alpha=0.25,
         mode="additive",
         bound="S",

--- a/skpro/regression/tests/test_cyclic_boosting.py
+++ b/skpro/regression/tests/test_cyclic_boosting.py
@@ -13,7 +13,6 @@ from skpro.tests.test_switch import run_test_for_class
 )
 def test_cyclic_boosting_simple_use():
     """Test simple use of cyclic boosting regressor."""
-    from cyclic_boosting import flags
     from sklearn.datasets import load_diabetes
     from sklearn.model_selection import train_test_split
 
@@ -25,20 +24,21 @@ def test_cyclic_boosting_simple_use():
     y = y.iloc[:50]
     X_train, X_test, y_train, y_test = train_test_split(X, y)
 
-    fp = {
-        "age": flags.IS_CONTINUOUS,
-        "sex": flags.IS_CONTINUOUS,
-        "bmi": flags.IS_CONTINUOUS,
-        "bp": flags.IS_CONTINUOUS,
-        "s1": flags.IS_CONTINUOUS,
-        "s2": flags.IS_CONTINUOUS,
-        "s3": flags.IS_CONTINUOUS,
-        "s4": flags.IS_CONTINUOUS,
-        "s5": flags.IS_CONTINUOUS,
-        "s6": flags.IS_CONTINUOUS,
-    }
+    features = [
+        "age",
+        "sex",
+        "bmi",
+        "bp",
+        "s1",
+        "s2",
+        "s3",
+        "s4",
+        "s5",
+        "s6",
+        ("age", "sex"),
+    ]
 
-    reg_proba = CyclicBoosting(feature_properties=fp)
+    reg_proba = CyclicBoosting(feature_groups=features)
     reg_proba.fit(X_train, y_train)
     y_pred = reg_proba.predict_proba(X_test)
 

--- a/skpro/regression/tests/test_cyclic_boosting.py
+++ b/skpro/regression/tests/test_cyclic_boosting.py
@@ -1,5 +1,6 @@
 """Tests for cyclic boosting regressor."""
 
+import pandas as pd
 import pytest
 
 from skpro.regression.cyclic_boosting import CyclicBoosting
@@ -19,6 +20,7 @@ def test_cyclic_boosting_simple_use():
     from skpro.regression.cyclic_boosting import CyclicBoosting
 
     X, y = load_diabetes(return_X_y=True, as_frame=True)
+    y = pd.DataFrame(y)
     X_train, X_test, y_train, y_test = train_test_split(X, y)
 
     fp = {

--- a/skpro/regression/tests/test_cyclic_boosting.py
+++ b/skpro/regression/tests/test_cyclic_boosting.py
@@ -1,13 +1,12 @@
 """Tests for cyclic boosting regressor."""
 
 import pytest
-
-from sktime.regression.cyclic_boosting import CyclicBoosting
-from sktime.tests.test_switch import run_test_for_class
+from skpro.regression.cyclic_boosting import CyclicBoosting
+from skpro.tests.test_switch import run_test_for_class
 
 
 @pytest.mark.skipif(
-    not run_test_for_class(CyclicBoosting)),
+    not run_test_for_class(CyclicBoosting),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
 def test_cyclic_boosting_simple_use():

--- a/skpro/regression/tests/test_cyclic_boosting.py
+++ b/skpro/regression/tests/test_cyclic_boosting.py
@@ -1,0 +1,41 @@
+"""Tests for cyclic boosting regressor."""
+
+import pytest
+
+from sktime.regression.cyclic_boosting import CyclicBoosting
+from sktime.tests.test_switch import run_test_for_class
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(CyclicBoosting)),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_cyclic_boosting_simple_use():
+    """Test simple use of cyclic boosting regressor."""
+    from cyclic_boosting import flags
+    from sklearn.datasets import load_diabetes
+    from sklearn.model_selection import train_test_split
+
+    from skpro.regression.cyclic_boosting import CyclicBoosting
+
+    X, y = load_diabetes(return_X_y=True, as_frame=True)
+    X_train, X_test, y_train, y_test = train_test_split(X, y)
+
+    fp = {
+        'age': flags.IS_CONTINUOUS,
+        'sex': flags.IS_CONTINUOUS,
+        'bmi': flags.IS_CONTINUOUS,
+        'bp':  flags.IS_CONTINUOUS,
+        's1':  flags.IS_CONTINUOUS,
+        's2':  flags.IS_CONTINUOUS,
+        's3':  flags.IS_CONTINUOUS,
+        's4':  flags.IS_CONTINUOUS,
+        's5':  flags.IS_CONTINUOUS,
+        's6':  flags.IS_CONTINUOUS,
+    }
+
+    reg_proba = CyclicBoosting(feature_properties=fp)
+    reg_proba.fit(X_train, y_train)
+    y_pred = reg_proba.predict_proba(X_test)
+
+    assert y_pred.shape == y_test.shape

--- a/skpro/regression/tests/test_cyclic_boosting.py
+++ b/skpro/regression/tests/test_cyclic_boosting.py
@@ -1,6 +1,7 @@
 """Tests for cyclic boosting regressor."""
 
 import pytest
+
 from skpro.regression.cyclic_boosting import CyclicBoosting
 from skpro.tests.test_switch import run_test_for_class
 
@@ -21,16 +22,16 @@ def test_cyclic_boosting_simple_use():
     X_train, X_test, y_train, y_test = train_test_split(X, y)
 
     fp = {
-        'age': flags.IS_CONTINUOUS,
-        'sex': flags.IS_CONTINUOUS,
-        'bmi': flags.IS_CONTINUOUS,
-        'bp':  flags.IS_CONTINUOUS,
-        's1':  flags.IS_CONTINUOUS,
-        's2':  flags.IS_CONTINUOUS,
-        's3':  flags.IS_CONTINUOUS,
-        's4':  flags.IS_CONTINUOUS,
-        's5':  flags.IS_CONTINUOUS,
-        's6':  flags.IS_CONTINUOUS,
+        "age": flags.IS_CONTINUOUS,
+        "sex": flags.IS_CONTINUOUS,
+        "bmi": flags.IS_CONTINUOUS,
+        "bp": flags.IS_CONTINUOUS,
+        "s1": flags.IS_CONTINUOUS,
+        "s2": flags.IS_CONTINUOUS,
+        "s3": flags.IS_CONTINUOUS,
+        "s4": flags.IS_CONTINUOUS,
+        "s5": flags.IS_CONTINUOUS,
+        "s6": flags.IS_CONTINUOUS,
     }
 
     reg_proba = CyclicBoosting(feature_properties=fp)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#132


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
new cyclic boosting interface. this interface predict j-qpd by quantile regression with Cyclic boosting, j-qpd's mean and variance values are passed as any probability distribution's paramerters. e.g. Normal distribution

#### Does your contribution introduce a new dependency? If yes, which one?
<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->
cyclic_boosting package >=1.2.1

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
Not yet

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
